### PR TITLE
bare tweets (non quote/non RT) will use full_text field if trimmed

### DIFF
--- a/R/tweets_and_users.R
+++ b/R/tweets_and_users.R
@@ -496,7 +496,7 @@ wrangle_retweet_status <- function(x) {
     x$retweet_text <- NA_character_
   }
   if (has_name(rst, "source")) {
-    x$retweet_source <- rst$source
+    x$retweet_source <- clean_source_(rst$source)
   } else {
     x$retweet_source <- NA_character_
   }
@@ -582,7 +582,7 @@ wrangle_quote_status <- function(x) {
     x$quoted_text <- NA_character_
   }
   if (has_name(qst, "source")) {
-    x$quoted_source <- qst$source
+    x$quoted_source <- clean_source_(qst$source)
   } else {
     x$quoted_source <- NA_character_
   }


### PR DESCRIPTION
This will match the functionality for tweets sent by the user alone, and seen in quote text and retweet_text. That is to say, we can go into the extended_tweet sublist to grab the full_text by checking the "truncated" field that is at the outermost level.