### PR TITLE
fix magrittr version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Depends:
 Imports:
     httr (>= 1.3.0),
     jsonlite (>= 0.9.22),
-    magrittr (>= 1.5.0),
+    magrittr (>= 1.5),
     tibble (>= 1.3.4),
     utils,
     progress,


### PR DESCRIPTION
Simple fix: it's 1.5, not 1.5.0. For R, they are equal. But this causes issues in other systems (e.g., RPM packaging). 