### PR TITLE
swap unroll_connections inputs/outputs to not mangle UTF-8 on windows

### DIFF
--- a/man/bearer_token.Rd
+++ b/man/bearer_token.Rd
@@ -39,21 +39,21 @@ authentication method
 verified_user_tweets <- search_tweets("filter:verified", n = 30000, token = bearer_token())
 
 ## get followers (user == app)
-### - USER (normal) token – rate limit 15req/15min
+### - USER (normal) token â€“ rate limit 15req/15min
 cnn_flw <- get_followers("cnn", n = 75000)
-### - APP (bearer) token – rate limit 15req/15min
+### - APP (bearer) token â€“ rate limit 15req/15min
 cnn_flw <- get_followers("cnn", n = 75000, token = bearer_token())
 
 ## get timelines (user < app)
-### - USER (normal) token – rate limit 900req/15min
+### - USER (normal) token â€“ rate limit 900req/15min
 cnn_flw_data <- get_timelines(cnn_flw$user_id[1:900])
-### - APP (bearer) token – rate limit 1500req/15min
+### - APP (bearer) token â€“ rate limit 1500req/15min
 cnn_flw_data <- get_timelines(cnn_flw$user_id[1:1500], token = bearer_token())
 
 ## lookup statuses (user > app)
-### - USER (normal) token – rate limit 900req/15min
+### - USER (normal) token â€“ rate limit 900req/15min
 cnn_flw_data2 <- lookup_tweets(cnn_flw_data$status_id[1:90000])
-### - APP (bearer) token – rate limit 300req/15min
+### - APP (bearer) token â€“ rate limit 300req/15min
 cnn_flw_data2 <- lookup_tweets(cnn_flw_data$status_id[1:30000], token = bearer_token())
 
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,13 +6,13 @@
 using namespace Rcpp;
 
 // unroll_connections
-List unroll_connections(CharacterVector from, std::vector<std::vector<std::string> > to);
+List unroll_connections(const CharacterVector& from, const List& to);
 RcppExport SEXP _rtweet_unroll_connections(SEXP fromSEXP, SEXP toSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< CharacterVector >::type from(fromSEXP);
-    Rcpp::traits::input_parameter< std::vector<std::vector<std::string> > >::type to(toSEXP);
+    Rcpp::traits::input_parameter< const CharacterVector& >::type from(fromSEXP);
+    Rcpp::traits::input_parameter< const List& >::type to(toSEXP);
     rcpp_result_gen = Rcpp::wrap(unroll_connections(from, to));
     return rcpp_result_gen;
 END_RCPP

--- a/src/unroll_connections.cpp
+++ b/src/unroll_connections.cpp
@@ -29,7 +29,7 @@ List unroll_connections(const CharacterVector& from,
   for (R_xlen_t i = 0; i < n; ++i) { 
     // `i` is index of current `to`
     const CharacterVector to_i = to[i];
-    
+    // `j` is index of current `to[i]`
     for (int j = 0; j < to_i.size(); ++j) {
       
       if (to_i[j].get() != R_NaString) {
@@ -41,15 +41,11 @@ List unroll_connections(const CharacterVector& from,
     }
     
   }
-  
-  Rcpp::List out = Rcpp::List::create(
-    _["from"] = from2,
-    _["to"] = to2
-  );
-  out.attr("row.names") = seq_len(len);
-  out.attr("class") = "data.frame";
-  
-  return out;
+  // combine the new [flat] vectors into a data frame (requires row names)
+  List df = List::create(_["from"] = from2,_["to"] = to2);
+  df.attr("row.names") = seq_len(len);
+  df.attr("class") = "data.frame";
+  return df;
 }
 
 

--- a/src/unroll_connections.cpp
+++ b/src/unroll_connections.cpp
@@ -20,8 +20,8 @@ List unroll_connections(const CharacterVector& from,
   }
   
   // use calculated lengths to initialize output character vectors
-  Rcpp::CharacterVector from2(len); 
-  Rcpp::CharacterVector to2(len); 
+  CharacterVector from2(len); 
+  CharacterVector to2(len); 
   
   // for each value of the 'from' vector, create appropriately re-sized from2
   // and to2 vectors

--- a/src/unroll_connections.cpp
+++ b/src/unroll_connections.cpp
@@ -3,44 +3,55 @@
 using namespace Rcpp;
 
 // [[Rcpp::export]]
-List unroll_connections(CharacterVector from, std::vector<std::vector<std::string> > to) {
+List unroll_connections(const CharacterVector& from,
+                        const List& to) {
   // set size paramaeters (exclude NAs from the 'to'-based output count)
   const int n = from.size();
-  int len = 0;
-  for (int i = 0; i < n; i++) {
-    if (to[i][0] != "NA") {
-      len += to[i].size();
-    }
-  }
-  // use calculated lengths to initialize output character vectors
-  CharacterVector from2(len);
-  CharacterVector to2(len);
-
-  // for each value of the 'from' vector, create appropriately re-sized from2
-  // and to2 vectors
-  int ctr = 0;
-  for (int i = 0; i < n; i++) {
-    int nn = to[i].size();
-    for (int j = 0; j < nn; j++) {
-      if (j == 0) {
-        if (to[i][j] != "NA") {
-          from2[ctr] = from[i];
-          to2[ctr] = to[i][j];
-          ctr += 1;
-        }
-      } else {
-        from2[ctr] = from[i];
-        to2[ctr] = to[i][j];
-        ctr += 1;
+  R_xlen_t len = 0;
+  for (R_xlen_t i = 0; i < n; ++i) {
+    const CharacterVector to_i = to[i];
+    
+    for (R_xlen_t j = 0; j < to_i.size(); ++j) {
+      if (to_i[j].get() != R_NaString) {
+        len++;
       }
     }
+    
   }
-  // combine the new [flat] vectors into a data frame (requires row names)
-  List df = List::create(_["from"] = from2, _["to"] = to2);
-  df.attr("class") = "data.frame";
-  df.attr("row.names") = seq(1, ctr);
-  return df;
+  
+  // use calculated lengths to initialize output character vectors
+  Rcpp::CharacterVector from2(len); 
+  Rcpp::CharacterVector to2(len); 
+  
+  // for each value of the 'from' vector, create appropriately re-sized from2
+  // and to2 vectors
+  R_xlen_t k = 0; // `k` is current index of `from2`/`to2`
+  for (R_xlen_t i = 0; i < n; ++i) { 
+    // `i` is index of current `to`
+    const CharacterVector to_i = to[i];
+    
+    for (int j = 0; j < to_i.size(); ++j) {
+      
+      if (to_i[j].get() != R_NaString) {
+        from2[k] = from[i];
+        to2[k] = to_i[j];
+        k++;
+      }
+      
+    }
+    
+  }
+  
+  Rcpp::List out = Rcpp::List::create(
+    _["from"] = from2,
+    _["to"] = to2
+  );
+  out.attr("row.names") = seq_len(len);
+  out.attr("class") = "data.frame";
+  
+  return out;
 }
+
 
 
 


### PR DESCRIPTION
I've been working on building twitter networks elsewhere and had already laid a foundation before realizing that rtweet now has some built-in functionality, so I've got some lessons-learned that may be of interest.

I changed `unroll_connections()` so that it doesn't mangle UTF-8 data on Windows (`std::string` pains); building networks such as user-to-hashtag will now be safe for Windows folks if that's something desired in the future.

The algorithm is a bit simpler than the previous one and skips the `std::vectors`. My benchmarks are showing that it's >= 3x faster.