### PR TITLE
Properly save TWITTER_PAT path on Windows.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rtweet
 Type: Package
-Version: 0.7.0
+Version: 0.7.0.9000
 Title: Collecting Twitter Data
 Authors@R: c(
     person("Michael W.", "Kearney", ,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rtweet 0.7.0
 
+- More robust handling of token path on Windows (#380, @jonthegeek).
+
+# rtweet 0.7.0
+
 - Added paper.md as part of ROpenSci submission.
 - Added contributing template.
 - Added explanation of requirements and usage to `bearer_token()` docs.

--- a/R/renv.R
+++ b/R/renv.R
@@ -8,9 +8,10 @@
 
 home <- function() {
   if (!identical(Sys.getenv("HOME"), "")) {
-    file.path(Sys.getenv("HOME"))
+    # Deal with mixed / and \\ returned by various base functions on Windows.
+    normalizePath(file.path(Sys.getenv("HOME")), winslash = "/")
   } else {
-    file.path(normalizePath("~"))
+    file.path(normalizePath("~", winslash = "/"))
   }
 }
 

--- a/tests/testthat/test_tokens.R
+++ b/tests/testthat/test_tokens.R
@@ -25,3 +25,11 @@ test_that("system_token functions", {
   expect_error(search_tweets("tweet", token = "token"))
   expect_error(search_tweets("stats", type = "all"))
 })
+
+test_that("file paths don't have mix of / and \\", {
+  filename <- uq_filename(file.path(home(), ".rtweet_token.rds"))
+  expect_true(
+    (grepl("/", filename) || grepl("\\\\", filename)) &&
+      !all(grepl("/", filename), grepl("\\\\", filename))
+  )
+})


### PR DESCRIPTION
Closes #380.

My .Renviron didn't like having `\\` in the path. Updated to normalize to `/`.