### PR TITLE
Define isFALSE if not available in base

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -429,6 +429,12 @@ na_omit <- function(x) {
   }
 }
 
+isFALSE <- if (is.element("package:base", find("isFALSE", mode = "function"))) {
+  base::isFALSE
+} else {
+  function(x) is.logical(x) && length(x) == 1L && !is.na(x) && !x
+}
+
 
 ##----------------------------------------------------------------------------##
 ##                            user type classifers                            ##


### PR DESCRIPTION
While the {rtweet} package's DESCRIPTION says it Depends on R (>= 3.1.0) the `isFALSE()` function used within the codebase is only available in [base R starting 3.5](https://cran.r-project.org/bin/windows/base/old/3.5.0/NEWS.R-3.5.0.html).

This causes functions calls such as:
```r
rtweet::get_timeline("jozefhajnala", n = 1)
``` 
to fail for users using R versions between >= 3.1.0 and < 3.5.0 with
> Error in isFALSE(dots[["parse"]]) : could not find function "isFALSE"

This PR proposes to define the `isFALSE()` function in the same way that base R >= 3.5 defines it in case the function is not found within base, therefore making the functionality available also to users using those versions of R.