### PR TITLE
fix parsing of path to token during auto-auth

### DIFF
--- a/R/tokens.R
+++ b/R/tokens.R
@@ -225,31 +225,10 @@ create_token_ <- function(app = "mytwitterapp",
   token
 }
 
-
-has_ext <- function(x) {
-  stopifnot(length(x) == 1L)
-  x <- basename(x)
-  grepl("[[:alnum:]]{1,}\\.[[:alpha:]]{1,}$", x)
-}
-
-only_ext <- function(x) {
-  if (has_ext(x)) {
-    gsub(".*(?=\\.)", "", x, perl = TRUE)
-  } else {
-    ""
-  }
-}
-
-no_ext <- function(x) {
-  if (has_ext(x)) {
-    gsub("(?<=[[:alnum:]]{1})\\..*(?!=\\.)", "", x, perl = TRUE)
-  } else {
-    x
-  }
-}
-
 paste_before_ext <- function(x, p) {
-  paste0(no_ext(x), p, only_ext(x))
+  ext = tools::file_ext(x)
+  pre = substring(x, 1L, nchar(x) - nchar(ext))
+  paste0(pre, p, ext)
 }
 
 


### PR DESCRIPTION
Closes #413 

The regex to do `no_ext` is wrong. See here:

https://regex101.com/r/12j8Xl/1

We could fix the regex, but I think the approach here is simpler & relies on existing `tools::file_ext` to find the file extension.

Alternatively, I think `no_ext` would work on `basename(x)`:

```
paste_before_ext = function(x) {
  f = basename(x)
  file.path(dirname(x), no_ext(f), p, only_ext(f))
}
```