### PR TITLE
Update rtweet-package.R

### DIFF
--- a/R/rtweet-package.R
+++ b/R/rtweet-package.R
@@ -16,7 +16,7 @@
 #' vignette("auth")
 #'
 #' ## for a quick demo check the rtweet vignette
-#' vignette("rtweet")
+#' vignette("intro", package = "rtweet")
 #' }
 "_PACKAGE"
 


### PR DESCRIPTION
There is no 'rtweet' vignette. I believe 'intro' is intended. RCurl also has a vignette called 'intro' so you must use the `package` argument to specify rtweet.