### PR TITLE
fixes reference to old and missing vignette in `get_token`, `get_tokens`

### DIFF
--- a/R/tokens.R
+++ b/R/tokens.R
@@ -92,8 +92,9 @@ request <- function (method = NULL, url = NULL, headers = NULL, fields = NULL,
 #' Call function used to fetch and load Twitter OAuth tokens.
 #' Since Twitter application key should be stored privately, users should save
 #' the path to token(s) as an environment variable. This allows Tokens
-#' to be instantly [re]loaded in future sessions. See the "tokens"
-#' vignette for instructions on obtaining and using access tokens.
+#' to be instantly [re]loaded in future sessions. See the tokens
+#' vignette i.e.,`vignettes("auth", "rtweet")` for instructions on 
+#' obtaining and using access tokens.
 #'
 #' @return Twitter OAuth token(s) (Token1.0).
 #' @details This function will search for tokens using R, internal,

--- a/docs/reference/get_tokens.html
+++ b/docs/reference/get_tokens.html
@@ -17,23 +17,27 @@
 <link rel="apple-touch-icon" type="image/png" sizes="60x60" href="../apple-touch-icon-60x60.png" />
 
 <!-- jquery -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha256-bZLfwXAP04zRMK2BjiO8iu9pf4FbLqX6zitd+tIvLhE=" crossorigin="anonymous" />
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" crossorigin="anonymous"></script>
+
+<!-- bootstrap-toc -->
+<link rel="stylesheet" href="../bootstrap-toc.css">
+<script src="../bootstrap-toc.js"></script>
 
 <!-- Font Awesome icons -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.1/css/all.min.css" integrity="sha256-PbSmjxuVAzJ6FPvNYsrXygfGhNJYyZ2GktDbkMBqQZg=" crossorigin="anonymous" />
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.1/css/v4-shims.min.css" integrity="sha256-A6jcAdwFD48VMjlI3GDxUd+eCQa7/KWy6G9oe/ovaPA=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/v4-shims.min.css" integrity="sha256-wZjR52fzng1pJHwx4aV2AO3yyTOXrcDW7jBpJtTwVxw=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" integrity="sha256-inc5kl9MA1hkeYUt+EC3BhlIgyp/2jDIyBLS6k3UxPI=" crossorigin="anonymous"></script>
 
 <!-- headroom.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.9.4/headroom.min.js" integrity="sha256-DJFC1kqIhelURkuza0AvYal5RxMtpzLjFhsnVIeuk+U=" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.9.4/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/headroom.min.js" integrity="sha256-AsUX4SJE1+yuDu5+mAVzJbuYNPHj/WroHuZ8Ir/CkE0=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/headroom/0.11.0/jQuery.headroom.min.js" integrity="sha256-ZX/yNShbjqsohH1k95liqY9Gd8uOiE1S4vZc+9KQ1K4=" crossorigin="anonymous"></script>
 
 <!-- pkgdown -->
 <link href="../pkgdown.css" rel="stylesheet">
@@ -48,10 +52,10 @@
 <meta property="og:description" content="Call function used to fetch and load Twitter OAuth tokens.
 Since Twitter application key should be stored privately, users should save
 the path to token(s) as an environment variable. This allows Tokens
-to be instantly [re]loaded in future sessions. See the &quot;tokens&quot;
-vignette for instructions on obtaining and using access tokens." />
+to be instantly [re]loaded in future sessions. See the tokens
+vignette i.e.,`vignettes(&quot;auth&quot;, &quot;rtweet&quot;)` for instructions on 
+obtaining and using access tokens." />
 <meta property="og:image" content="https://rtweet.info/logo.png" />
-<meta name="twitter:card" content="summary" />
 
 
 
@@ -69,7 +73,7 @@ vignette for instructions on obtaining and using access tokens." />
 
   </head>
 
-  <body>
+  <body data-spy="scroll" data-target="#toc">
     <div class="container template-reference-topic">
       <header>
       <div class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -144,7 +148,7 @@ vignette for instructions on obtaining and using access tokens." />
   <div class="col-md-9 contents">
     <div class="page-header">
     <h1>Fetching Twitter authorization token(s).</h1>
-    
+    <small class="dont-index">Source: <a href='https://github.com/ropensci/rtweet/blob/master/R/tokens.R'><code>R/tokens.R</code></a></small>
     <div class="hidden name"><code>get_tokens.Rd</code></div>
     </div>
 
@@ -152,8 +156,9 @@ vignette for instructions on obtaining and using access tokens." />
     <p>Call function used to fetch and load Twitter OAuth tokens.
 Since Twitter application key should be stored privately, users should save
 the path to token(s) as an environment variable. This allows Tokens
-to be instantly [re]loaded in future sessions. See the "tokens"
-vignette for instructions on obtaining and using access tokens.</p>
+to be instantly [re]loaded in future sessions. See the tokens
+vignette i.e.,`vignettes("auth", "rtweet")` for instructions on 
+obtaining and using access tokens.</p>
     </div>
 
     <pre class="usage"><span class='fu'>get_tokens</span>()
@@ -185,15 +190,10 @@ vignette for instructions on obtaining and using access tokens.</p>
 
 }</div></pre>
   </div>
-  <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
-    <h2>Contents</h2>
-    <ul class="nav nav-pills nav-stacked">
-      <li><a href="#value">Value</a></li>
-      <li><a href="#details">Details</a></li>
-      <li><a href="#see-also">See also</a></li>
-      <li><a href="#examples">Examples</a></li>
-    </ul>
-
+  <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
+    <nav id="toc" data-toggle="toc" class="sticky-top">
+      <h2 data-toc-skip>Contents</h2>
+    </nav>
   </div>
 </div>
 
@@ -204,7 +204,7 @@ vignette for instructions on obtaining and using access tokens.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.4.1.9000.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
 </div>
 
       </footer>

--- a/man/get_tokens.Rd
+++ b/man/get_tokens.Rd
@@ -16,8 +16,9 @@ Twitter OAuth token(s) (Token1.0).
 Call function used to fetch and load Twitter OAuth tokens.
 Since Twitter application key should be stored privately, users should save
 the path to token(s) as an environment variable. This allows Tokens
-to be instantly [re]loaded in future sessions. See the "tokens"
-vignette for instructions on obtaining and using access tokens.
+to be instantly [re]loaded in future sessions. See the tokens
+vignette i.e.,`vignettes("auth", "rtweet")` for instructions on 
+obtaining and using access tokens.
 }
 \details{
 This function will search for tokens using R, internal,


### PR DESCRIPTION
Previously the documentation in `tokens.r` showed this:

```
...
#' to be instantly [re]loaded in future sessions. See the "tokens"
#' vignette for instructions on obtaining and using access tokens.
...
```
Which refers a vignette that has been replaced by one named "auth" as reference in other .R documentation files. Found this confusing when trying to get help from ?get_tokens and couldn't find the vignette from my rsession and had to navigate to the website to figure out the vignette didn't exist. 

Updated `tokens.r`, and generated `get_tokens.rd` and `.../get_tokens.html` by calling `devtools:document()` and `pkgdown::build_articles`