### PR TITLE
No deletion of stream folder

### DIFF
--- a/R/stream.R
+++ b/R/stream.R
@@ -526,7 +526,7 @@ stream_tweets2 <- function(..., dir = NULL, append = FALSE) {
   pat <- paste0(file_name, "\\-[[:digit:]]{1,}\\.json$")
   jsons <- list.files(dir, pattern = pat, full.names = TRUE)
   file_name <- paste0(dir, ".json")
-  unlink(dir, recursive = TRUE)
+  #unlink(dir, recursive = TRUE)
   if (!parse) {
     return(invisible())
   }


### PR DESCRIPTION
Should close #294. Thanks @Kwazao!

Although a better path it might be just deprecate the function stream_tweets2. As noted on the comments it is not the best place to test functions. But now that people use it at least make it work as well as possible. 