### PR TITLE
Update R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(
 Description: An implementation of calls designed to collect and organize Twitter data via Twitter's REST and stream Application Program Interfaces (API), which can be found at the following URL: <https://developer.twitter.com/en/docs>.
  This package has been peer-reviewed by rOpenSci (v. 0.6.9).
 Depends:
-    R (>= 3.1.0)
+    R (>= 3.5.0)
 Imports:
     httr (>= 1.3.0),
     jsonlite (>= 0.9.22),


### PR DESCRIPTION
Updates the minimum version required because the package uses isFalse identified in #385. I think the suggestion of #385 although good will make it harder if I had to support versions of 7 years ago.

Closes #385 and #446.

@sckott @mkearney 