### PR TITLE
Remove Rcpp and document again

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
     tibble (>= 1.3.4),
     utils,
     progress,
-    Rcpp,
     httpuv
 License: MIT + file LICENSE
 URL: https://CRAN.R-project.org/package=rtweet
@@ -45,4 +44,4 @@ Suggests:
     igraph
 VignetteBuilder: knitr
 LazyData: yes
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1

--- a/man/emojis.Rd
+++ b/man/emojis.Rd
@@ -4,7 +4,9 @@
 \name{emojis}
 \alias{emojis}
 \title{Emojis codes and descriptions data.}
-\format{A tibble with two variables and 2,623 observations.}
+\format{
+A tibble with two variables and 2,623 observations.
+}
 \usage{
 emojis
 }

--- a/man/langs.Rd
+++ b/man/langs.Rd
@@ -4,7 +4,9 @@
 \name{langs}
 \alias{langs}
 \title{Language codes recognized by Twitter data.}
-\format{A tibble with five variables and 486 observations.}
+\format{
+A tibble with five variables and 486 observations.
+}
 \usage{
 langs
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -11,6 +11,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{magrittr}{\code{\link[magrittr]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}}
 }}
 

--- a/man/stopwordslangs.Rd
+++ b/man/stopwordslangs.Rd
@@ -4,7 +4,9 @@
 \name{stopwordslangs}
 \alias{stopwordslangs}
 \title{Twitter stop words in multiple languages data.}
-\format{A tibble with three variables and 24,000 observations}
+\format{
+A tibble with three variables and 24,000 observations
+}
 \usage{
 stopwordslangs
 }


### PR DESCRIPTION
Removes Rcpp and documents should fix the note from CRAN: "Namespace in Imports field not imported from: ‘Rcpp’".
If other things get merged before I will need to re-document again once this gets merged.

@sckott @mkearney 