### PR TITLE
Use inheritParams to reduce duplication in docs

### DIFF
--- a/R/bearer_token.R
+++ b/R/bearer_token.R
@@ -32,8 +32,7 @@ create_bearer_token <- function(token = NULL) {
 #' Convert default token into bearer token for application only (user-free)
 #' authentication method
 #'
-#' @param token Oauth token created via \code{\link{create_token}}. See details
-#'   for more information on valid tokens.
+#' @inheritParams lookup_users
 #' @return A bearer token
 #' @details \code{bearer_token()} will only work on valid tokens generated from
 #'   a user-created Twitter app (requires a Twitter developer account; see
@@ -121,7 +120,7 @@ print.bearer <- function(bearer) {
 
 #' Invalidate bearer token
 #'
-#' @param token Oauth token created via \code{\link{create_token}}.
+#' @inheritParams lookup_users
 #' @keywords internal
 #' @export
 invalidate_bearer <- function(token = NULL) {

--- a/R/collections.R
+++ b/R/collections.R
@@ -8,14 +8,7 @@
 #'   e.g., "custom-539487832448843776"
 #' @param n Specifies the maximum number of results to include in
 #'   the response. Specify count between 1 and 200.
-#' @param parse Logical indicating whether to convert response object into
-#'   nested list. Defaults to true.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @param ... Other arguments passed along to composed request query.
 #' @return Return object converted to nested list if parsed otherwise
 #'   an HTTP response object is returned.
@@ -68,14 +61,7 @@ lookup_collections <- function(id, n = 200,
 #' @param cursor Page identifier of results to retrieve. If parse = TRUE,
 #'   the next cursor value for any given request--if available--is stored
 #'   as an attribute, accessible via \code{\link{next_cursor}}
-#' @param parse Logical indicating whether to convert response object
-#'   into nested list. Defaults to true.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @return Return object converted to nested list if parsed otherwise
 #'   an HTTP response object is returned.
 #' @examples

--- a/R/direct_messages.R
+++ b/R/direct_messages.R
@@ -9,14 +9,7 @@
 #' @param next_cursor If there are more than 200 DMs in the last 30 days,
 #'   responses will include a next_cursor value, which can be supplied in
 #'   additional requests to scroll through pages of results.
-#' @param parse Logical indicating whether to convert response object
-#'   into nested list. Defaults to true.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @return Return parsed or non-parsed response object.
 #' @examples
 #'
@@ -81,14 +74,7 @@ direct_messages <- function(n = 50,
 #'   thought of as a limit to the number of Tweets to return because
 #'   suspended or deleted content is removed after the count has been
 #'   applied.
-#' @param parse Logical indicating whether to convert response object
-#'   into nested list. Defaults to true.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @return Return object converted to nested list. If status code of
 #'   response object is not 200, the response object is returned
 #'   directly.

--- a/R/favorites.R
+++ b/R/favorites.R
@@ -16,16 +16,7 @@
 #'   available.
 #' @param max_id Character, returns results with an ID less than (that is,
 #'   older than) or equal to `max_id`.
-#' @param parse Logical, indicating whether to return parsed vector or
-#'   nested list object. By default, \code{parse = TRUE}
-#'   saves you the time [and frustrations] associated with
-#'   disentangling the Twitter API return objects.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @return A tbl data frame of tweets data with users data attribute.
 #' @examples
 #'

--- a/R/followers.R
+++ b/R/followers.R
@@ -4,6 +4,7 @@
 #' user. To return more than 75,000 user IDs in a single call (the
 #' rate limit maximum), set "retryonratelimit" to TRUE.
 #'
+#' @inheritParams lookup_users
 #' @param user Screen name or user ID of target user from which the
 #'   user IDs of followers will be retrieved.
 #' @param n Number of followers to return. Defaults to 5000, which is
@@ -29,16 +30,6 @@
 #' @param verbose Logical indicating whether or not to print messages.
 #'   Only relevant if retryonratelimit = TRUE. Defaults to TRUE,
 #'   prints sleep times and followers gathered counts.
-#' @param parse Logical, indicating whether to return parsed vector or
-#'   nested list object. By default, \code{parse = TRUE}
-#'   saves you the time [and frustrations] associated with
-#'   disentangling the Twitter API return objects.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @details When \code{retryonratelimit = TRUE} this function
 #'   internally makes a rate limit API call to get information on (a)
 #'   the number of requests remaining and (b) the amount of time until

--- a/R/friends.R
+++ b/R/friends.R
@@ -5,6 +5,7 @@
 #' in a single call (the rate limit maximum), set "retryonratelimit"
 #' to TRUE.
 #'
+#' @inheritParams lookup_users
 #' @param users Screen name or user ID of target user from which the
 #'   user IDs of friends (accounts followed BY target user) will be
 #'   retrieved.
@@ -31,19 +32,9 @@
 #'   results. Other pages specified via cursor values supplied by
 #'   Twitter API response object. This is only relevant if a user has
 #'   over 5000 friends (follows more than 5000 accounts).
-#' @param parse Logical, indicating whether to return parsed vector or
-#'   nested list object. By default, \code{parse = TRUE}
-#'   saves you the time [and frustrations] associated with
-#'   disentangling the Twitter API return objects.
 #' @param verbose Logical indicating whether or not to include output
 #'   messages. Defaults to TRUE, which includes printing a success message
 #'   for each inputted user.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @seealso \url{https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids}
 #' @examples
 #'
@@ -281,13 +272,8 @@ get_friend_nosp <- function(url, token = NULL) {
 #' Gets information on friendship between authenticated user and up
 #' to 100 other users.
 #'
+#' @inheritParams lookup_users
 #' @param user Screen name or user id of target user.
-#' @param parse Logical indicating whether to return parsed data frame.
-#'   Defaults to true.
-#' @param token OAuth token. By default \code{token = NULL} fetches a
-#'   non-exhausted token from an environment variable. Find instructions
-#'   on how to create tokens and setup an environment variable in the
-#'   tokens vignette (in r, send \code{?tokens} to console).
 #' @return Data frame converted form returned JSON object. If parse is
 #'   not true, the HTTP response object is returned instead.
 #' @family friends
@@ -354,16 +340,9 @@ lookup_friendships_ <- function(source,
 #'
 #' Gets information on friendship between two Twitter users.
 #'
+#' @inheritParams lookup_users
 #' @param source Screen name or user id of source user.
 #' @param target Screen name or user id of target user.
-#' @param parse Logical indicating whether to return parsed data frame.
-#'   Defaults to true.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @return Data frame converted form returned JSON object. If parse is
 #'   not true, the HTTP response object is returned instead.
 #' @family friends

--- a/R/get-my-timeline.R
+++ b/R/get-my-timeline.R
@@ -7,23 +7,14 @@
 #' The _authenticating user_ is determined from the `token`.
 #'
 #' @md
+#' @inheritParams lookup_users
 #' @param n Number of tweets to return per timeline. Defaults to 100.
 #'   Must be of length 1 or equal to length of user.
 #' @param max_id Character, returns results with an ID less than (that is,
 #'   older than) or equal to `max_id`.
-#' @param parse Logical, indicating whether to return parsed
-#'   (data.frames) or nested list object. By default, \code{parse =
-#'   TRUE} saves users from the time (and frustrations) associated
-#'   with disentangling the Twitter API return objects.
 #' @param check Logical indicating whether to remove check available
 #'   rate limit. Ensures the request does not exceed the maximum
 #'   remaining number of calls.  Defaults to TRUE.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @param ... Further arguments passed on as parameters in API query.
 #' @return A tbl data frame of tweets data with users data attribute.
 #' @seealso

--- a/R/lists_members.R
+++ b/R/lists_members.R
@@ -17,14 +17,7 @@
 #'   value of -1 to begin paging. Provide values as returned in the
 #'   response body's next_cursor and previous_cursor attributes to
 #'   page back and forth in the list.
-#' @param parse Logical indicating whether to convert the response object into
-#'   an R list. Defaults to TRUE.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @param ... Other arguments used as parameters in query composition.
 #' @return Either a nested list (if parsed) or an HTTP response object.
 #' @examples

--- a/R/lists_statuses.R
+++ b/R/lists_statuses.R
@@ -20,14 +20,7 @@
 #'   addition to the standard stream of tweets. The output format of
 #'   retweeted tweets is identical to the representation you see in
 #'   home_timeline.
-#' @param parse Logical indicating whether to convert the response object into
-#'   an R list. Defaults to TRUE.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @family lists
 #' @family tweets
 #' @return data

--- a/R/lists_subscribers.R
+++ b/R/lists_subscribers.R
@@ -17,14 +17,7 @@
 #'   The response from the API will include a previous_cursor
 #'   and next_cursor to allow paging back and forth. See Using
 #'   cursors to navigate collections for more information.
-#' @param parse Logical indicating whether to convert the response object into
-#'   an R list. Defaults to TRUE.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @examples
 #'
 #' \dontrun{

--- a/R/lists_subscriptions.R
+++ b/R/lists_subscriptions.R
@@ -11,14 +11,7 @@
 #'   The response from the API will include a previous_cursor
 #'   and next_cursor to allow paging back and forth. See Using
 #'   cursors to navigate collections for more information.
-#' @param parse Logical indicating whether to convert the response object into
-#'   an R list. Defaults to TRUE.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @examples
 #'
 #' \dontrun{

--- a/R/lists_users.R
+++ b/R/lists_users.R
@@ -4,14 +4,7 @@
 #' @param reverse optional Set this to true if you would like owned lists
 #'   to be returned first. See description above for information on
 #'   how this parameter works.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
-#' @param parse Logical indicating whether to convert the response object into
-#'   an R list. Defaults to TRUE.
+#' @inheritParams lookup_users
 #' @return data
 #' @examples
 #' \dontrun{

--- a/R/mentions.R
+++ b/R/mentions.R
@@ -15,14 +15,7 @@
 #'   will be forced to the oldest ID available.
 #' @param max_id Character, returns results with an ID less than (that is,
 #'   older than) or equal to `max_id`.
-#' @param parse Logical indicating whether to convert the response
-#'   object into an R list. Defaults to TRUE.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @param ... Other arguments passed as parameters in composed API
 #'   query.
 #' @return Tibble of mentions data.

--- a/R/post.R
+++ b/R/post.R
@@ -1,11 +1,10 @@
 #' Posts status update to user's Twitter account
 #'
+#' @inheritParams lookup_users
 #' @param status Character, tweet status. Must be 280 characters or less.
 #' @param media Length 1 character vector with a file path to video media **OR** 
 #'     up-to length 4 character vector with file paths to static images to be included in tweet.
 #'     **The caller is responsible for managing this.**
-#' @param token OAuth token. By default \code{token = NULL} fetches a
-#'   non-exhausted token from an environment variable tokens.
 #' @param in_reply_to_status_id Status ID of tweet to which you'd like to reply.
 #'   Note: in line with the Twitter API, this parameter is ignored unless the
 #'   author of the tweet this parameter references is mentioned within the
@@ -206,9 +205,7 @@ is_tweet_length <- function(.x, n = 280) {
 #' Uploads media using chunked media endpoint
 #'
 #' @param media Path to media file (image or movie) to upload. 
-#' @param token OAuth token. By default \code{token = NULL}
-#'   fetches a non-exhausted token from an environment
-#'   variable tokens.
+#' @inheritParams lookup_users
 #' @noRd 
 upload_media_to_twitter <- function(media, token = NULL, alt_text = NULL) {
   media2upload <- httr::upload_file(media)
@@ -284,10 +281,8 @@ upload_media_to_twitter <- function(media, token = NULL, alt_text = NULL) {
 
 #' Checks status of chunked media upload`
 #'
+#' @inheritParams lookup_users
 #' @param finalize_data Output of FINALIZE or STATUS command.
-#' @param token OAuth token. By default \code{token = NULL}
-#'   fetches a non-exhausted token from an environment
-#'   variable tokens.
 #' @param rurl Upload address for media.
 #' @importFrom httr GET content
 #' @noRd 
@@ -309,13 +304,11 @@ check_chunked_media_status = function(finalize_data, token, rurl) {
 
 #' Posts direct message from user's Twitter account
 #'
+#' @inheritParams lookup_users
 #' @param text Character, text of message.
 #' @param user Screen name or user ID of message target.
 #' @param media File path to image or video media to be
 #'   included in tweet.
-#' @param token OAuth token. By default \code{token = NULL}
-#'   fetches a non-exhausted token from an environment
-#'   variable tokens.
 #' @importFrom httr POST upload_file content
 #' @export
 post_message <- function(text, user, media = NULL, token = NULL) {
@@ -364,6 +357,7 @@ post_message <- function(text, user, media = NULL, token = NULL) {
 
 #' Follows target twitter user.
 #'
+#' @inheritParams lookup_users
 #' @param user Screen name or user id of target user.
 #' @param destroy Logical indicating whether to post (add) or
 #'   remove (delete) target tweet as favorite.
@@ -374,9 +368,6 @@ post_message <- function(text, user, media = NULL, token = NULL) {
 #'   for target user. Defaults to false.
 #' @param retweets Logical indicating whether to enable retweets
 #'   for target user. Defaults to true.
-#' @param token OAuth token. By default \code{token = NULL}
-#'   fetches a non-exhausted token from an environment
-#'   variable tokens.
 #' @aliases follow_user
 #' @examples
 #' \dontrun{
@@ -483,14 +474,12 @@ post_mute <- function(user, token = NULL) {
 
 #' Favorites target status id.
 #'
+#' @inheritParams lookup_users
 #' @param status_id Status id of target tweet.
 #' @param destroy Logical indicating whether to post (add) or
 #'   remove (delete) target tweet as favorite.
 #' @param include_entities Logical indicating whether to
 #'   include entities object in return.
-#' @param token OAuth token. By default \code{token = NULL}
-#'   fetches a non-exhausted token from an environment
-#'   variable tokens.
 #' @aliases post_favourite favorite_tweet
 #' @examples
 #' \dontrun{
@@ -530,15 +519,13 @@ post_favorite <- function(status_id,
 
 #' Updates friendship notifications and retweet abilities.
 #'
+#' @inheritParams lookup_users
 #' @param user Screen name or user id of target user.
 #' @param device Logical indicating whether to enable or disable
 #'    device notifications from target user behaviors. Defaults
 #'    to false.
 #' @param retweets Logical indicating whether to enable or disable
 #'    retweets from target user behaviors. Defaults to false.
-#' @param token OAuth token. By default \code{token = NULL}
-#'   fetches a non-exhausted token from an environment
-#'   variable tokens.
 #' @aliases friendship_update
 #' @family post
 #' @export
@@ -815,6 +802,7 @@ post_list_destroy_all <- function(users,
 #'
 #' Create, add users, and destroy Twitter lists
 #'
+#' @inheritParams lookup_users
 #' @param users Character vectors of users to be added to list.
 #' @param name Name of new list to create.
 #' @param description Optional, description of list (single character string).
@@ -825,8 +813,6 @@ post_list_destroy_all <- function(users,
 #'   `slug` must be provided if `destroy = TRUE`.
 #' @param list_id Optional, numeric ID of list.
 #' @param slug Optional, list slug.
-#' @param token OAuth token associated with user who owns [or will own] the list
-#'   of interest. Token must have write permissions!
 #' @return Response object from HTTP request.
 #' @examples
 #' \dontrun{

--- a/R/premium.R
+++ b/R/premium.R
@@ -47,14 +47,11 @@ format_from_to_date <- function(x = NULL) {
 #' @param toDate Newest date-time (YYYYMMDDHHMM) from which tweets should be
 #'   searched for.
 #' @param env_name Name/label of developer environment to use for the search.
-#' @param parse Logical indicating whether to convert data into data frame.
 #' @param safedir Name of directory to which each response object should be
 #'   saved. If the directory doesn't exist, it will be created. If NULL (the
 #'   default) then a dir will be created in the current working directory. To
 #'   override/deactivate safedir set this to FALSE.
-#' @param token A token associated with a user-created APP (requires a developer
-#'   account), which is converted to a bearer token in order to make premium
-#'   API requests
+#' @inheritParams lookup_users
 #'
 #' @section Developer Account:
 #' Users must have an approved developer account and an active/labeled

--- a/R/rate_limit.R
+++ b/R/rate_limit.R
@@ -4,11 +4,7 @@
 #' optionally filtered by rtweet function or specific Twitter API
 #' path(s)
 #'
-#' @param token One or more OAuth tokens. By default token = NULL
-#'   fetches a non-exhausted token from an environment variable. Find
-#'   instructions on how to create tokens and setup an environment
-#'   variable in the tokens vignette (in r, send \code{?tokens} to
-#'   console).
+#' @inheritParams lookup_users
 #' @param query Specific API (path) or a character function name,
 #'   e.g., query = "get_timeline", used to subset the returned data.
 #'   If null, this function returns entire rate limit request object
@@ -18,8 +14,6 @@
 #'   "followers/ids" returns remaining limit for follower id requests;
 #'   type = "friends/ids" returns remaining limit for friend id
 #'   requests.
-#' @param parse Logical indicating whether to parse response object
-#'   into a data frame.
 #' @seealso
 #'   \url{https://developer.twitter.com/en/docs/developer-utilities/rate-limit-status/api-reference/get-application-rate_limit_status}
 #' @details If multiple tokens are provided, this function will return

--- a/R/retweets.R
+++ b/R/retweets.R
@@ -4,17 +4,10 @@
 #' status.  NOTE: Twitter's API is currently limited to 100 or fewer
 #' retweeters.
 #'
+#' @inheritParams lookup_users
 #' @param status_id required The numerical ID of the desired status.
 #' @param n optional Specifies the number of records to retrieve.
 #'   Must be less than or equal to 100.
-#' @param parse Logical indicating whether to convert the response
-#'   object into an R list. Defaults to TRUE.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @param ... Other arguments used as parameters in the query sent to
 #'   Twitter's rest API, for example, \code{trim_user = TRUE}.
 #' @return Tweets data of the most recent retweets of a given status
@@ -47,17 +40,10 @@ get_retweets <- function(status_id, n = 100, parse = TRUE, token = NULL, ...) {
 #' current time, this function is limited in returning a maximum of
 #' 100 users for a given status.
 #'
+#' @inheritParams lookup_users
 #' @param status_id required The status ID of the desired status.
 #' @param n Specifies the number of records to retrieve.  Best if
 #'   intervals of 100.
-#' @param parse Logical indicating whether to convert the response
-#'   object into an R list. Defaults to TRUE.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @return data
 #' @details At time of writing, pagination offers no additional
 #'   data.

--- a/R/search_tweets.R
+++ b/R/search_tweets.R
@@ -5,6 +5,7 @@
 #' than 18,000 statuses in a single call, set "retryonratelimit" to
 #' TRUE.
 #'
+#' @inheritParams lookup_users
 #' @param q Query to be searched, used to filter and select tweets to
 #'   return from Twitter's REST API. Must be a character string not to
 #'   exceed maximum of 500 characters. Spaces behave like boolean
@@ -66,25 +67,6 @@
 #'   leverage \code{retryonratelimit} for sets of tweets and
 #'   \code{max_id} to allow results to continue where previous efforts
 #'   left off.
-#' @param parse Logical, indicating whether to return parsed
-#'   data.frame, if true, or nested list, if false. By default,
-#'   \code{parse = TRUE} saves users from the wreck of time and
-#'   frustration associated with disentangling the nasty nested list
-#'   returned from Twitter's API. As Twitter's APIs are subject to
-#'   change, this argument would be especially useful when changes to
-#'   Twitter's APIs affect performance of internal parsers. Setting
-#'   \code{parse = FALSE} also ensures the maximum amount of possible
-#'   information is returned. By default, the rtweet parse process
-#'   returns nearly all bits of information returned from
-#'   Twitter. However, users may occasionally encounter new or
-#'   omitted variables. In these rare cases, the nested list object
-#'   will be the only way to access these variables.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @param retryonratelimit Logical indicating whether to wait and
 #'   retry when rate limited. This argument is only relevant if the
 #'   desired return (n) exceeds the remaining limit of available

--- a/R/search_users.R
+++ b/R/search_users.R
@@ -3,6 +3,7 @@
 #' Returns data for up to 1,000 users matched by user provided search
 #' query.
 #'
+#' @inheritParams lookup_users
 #' @param q Query to be searched, used in filtering relevant tweets to
 #'   return from Twitter's REST API. Should be a character string not
 #'   to exceed 500 characters maximum. Spaces are assumed to function
@@ -20,16 +21,6 @@
 #' @param n Numeric, specifying the total number of desired users to
 #'   return. Defaults to 100. Maximum number of users returned from a
 #'   single search is 1,000.
-#' @param parse Logical, indicating whether to return parsed
-#'   (data.frames) or nested list object. By default,
-#'   \code{parse = TRUE} saves users from the time [and frustrations]
-#'   associated with disentangling the Twitter API return objects.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @param verbose Logical, indicating whether or not to output
 #'   processing/retrieval messages.
 #' @seealso \url{https://dev.twitter.com/overview/documentation}

--- a/R/statuses.R
+++ b/R/statuses.R
@@ -4,15 +4,8 @@
 #' more than 90,000 statuses, users must iterate through status IDs
 #' whilst avoiding rate limits, which reset every 15 minutes.
 #'
+#' @inheritParams lookup_users
 #' @param statuses User id or screen name of target user.
-#' @param parse Logical, indicating whether or not to parse
-#'   return object into data frame(s).
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @seealso \url{https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-lookup}
 #' @examples
 #'

--- a/R/stream.R
+++ b/R/stream.R
@@ -11,6 +11,7 @@
 #'     \item 4. Location via geo coordinates (1-360 degree
 #'              location boxes)
 #'   }
+#' @inheritParams lookup_users
 #' @param q Query used to select and customize streaming collection
 #'   method.  There are four possible methods. (1) The default,
 #'   \code{q = ""}, returns a small random sample of all publicly
@@ -25,22 +26,6 @@
 #'   tweets.  By default, this is set to 30 seconds. To stream
 #'   indefinitely, use \code{timeout = FALSE} to ensure JSON file is
 #'   not deleted upon completion or \code{timeout = Inf}.
-#' @param parse Logical, indicating whether to return parsed data.  By
-#'   default, \code{parse = TRUE}, this function does the parsing for
-#'   you. However, for larger streams, or for automated scripts
-#'   designed to continuously collect data, this should be set to
-#'   false as the parsing process can eat up processing resources and
-#'   time. For other uses, setting parse to TRUE saves you from having
-#'   to sort and parse the messy list structure returned by
-#'   Twitter. (Note: if you set parse to false, you can use the
-#'   \code{\link{parse_stream}} function to parse the JSON file at a
-#'   later point in time.)
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @param file_name Character with name of file. By default, a
 #'   temporary file is created, tweets are parsed and returned to
 #'   parent environment, and the temporary file is deleted.

--- a/R/suggested.R
+++ b/R/suggested.R
@@ -19,18 +19,11 @@ suggested_slugs <- function(lang = NULL, token = NULL) {
 
 #' Returns users from a specific, suggested category
 #'
+#' @inheritParams lookup_users
 #' @param slug required The short name of list or a category
 #' @param lang optional Restricts the suggested categories to the
 #'   requested language. The language must be specified by the
 #'   appropriate two letter ISO 639-1 representation.
-#' @param parse Logical indicating whether to parse the returned data into
-#'   a tibble data frame. See details for more on the returned users data.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @details Currently, this parsing process drops all
 #'   recursive (list) columns, which mostly means you are shorted some
 #'   entities data. To maximize users data, however, it is recommended to
@@ -90,12 +83,7 @@ suggested_users <- function(slug, lang = NULL, parse = TRUE, token = NULL) {
 #' @param slugs Optional, one or more slugs returned by
 #'   \code{\link{suggested_slugs}}. API rate limits this to 15 max (function
 #'   will return warnings for slugs provided beyond the remaining limit).
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
+#' @inheritParams lookup_users
 #' @export
 #' @rdname suggested_users
 suggested_users_all <- function(slugs = NULL, parse = TRUE, token = NULL) {

--- a/R/timeline.R
+++ b/R/timeline.R
@@ -3,6 +3,7 @@
 #' Returns up to 3,200 statuses posted to the timelines of each of one
 #' or more specified Twitter users.
 #'
+#' @inheritParams lookup_users
 #' @param user Vector of user names, user IDs, or a mixture of both.
 #' @param n Number of tweets to return per timeline. Defaults to 100.
 #'   Must be of length 1 or equal to length of user. This number should
@@ -15,19 +16,9 @@
 #'   \code{get_timeline} returns tweets posted by the given user. To
 #'   return a user's home timeline feed, that is, the tweets posted by
 #'   accounts followed by a user, set home to TRUE.
-#' @param parse Logical, indicating whether to return parsed
-#'   (data.frames) or nested list object. By default, \code{parse =
-#'   TRUE} saves users from the time [and frustrations] associated
-#'   with disentangling the Twitter API return objects.
 #' @param check Logical indicating whether to remove check available
 #'   rate limit. Ensures the request does not exceed the maximum
 #'   remaining number of calls.  Defaults to TRUE.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instructions on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
 #' @param ... Further arguments passed on as parameters in API query.
 #' @return A tbl data frame of tweets data with users data attribute.
 #' @seealso

--- a/R/trends.R
+++ b/R/trends.R
@@ -1,5 +1,6 @@
 #' Get Twitter trends data.
 #'
+#' @inheritParams lookup_users
 #' @param woeid Numeric, WOEID (Yahoo! Where On Earth ID) or character
 #'   string of desired town or country. Users may also supply latitude
 #'   and longitude coordinates to fetch the closest available trends
@@ -17,14 +18,6 @@
 #' @param exclude_hashtags Logical, indicating whether or not to
 #'   exclude hashtags. Defaults to FALSE--meaning, hashtags are
 #'   included in returned trends.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
-#' @param parse Logical, indicating whether or not to parse return
-#'   trends data. Defaults to true.
 #' @examples
 #'
 #' \dontrun{
@@ -177,15 +170,7 @@ format_trend_date <- function(x) {
 
 #' Available Twitter trends along with associated WOEID.
 #'
-#' @param token OAuth token. By default \code{token = NULL} fetches a
-#'   non-exhausted token from an environment variable. Find instructions
-#'   on how to create tokens and setup an environment variable in the
-#'   tokens vignette (in r, send \code{?tokens} to console).
-#' @param parse Logical, indicating whether to return parsed
-#'   (data.frames) or nested list object. By default,
-#'   \code{parse = TRUE} saves users from the time
-#'   [and frustrations] associated with disentangling the Twitter
-#'   API return objects.
+#' @inheritParams lookup_users
 #'
 #' @examples
 #' \dontrun{

--- a/R/users.R
+++ b/R/users.R
@@ -4,17 +4,20 @@
 #' than 90,000 users, code must be written to iterate through user IDs
 #' whilst avoiding rate limits, which reset every 15 minutes.
 #'
+#' @param token An OAuth token object. The default, \code{NULL}, will retrieve
+#'   a default token with \code{\link{get_token}()}. You should only need to 
+#'   use this argument if you are wrapping rtweet in a package. 
+#'   
+#'   See \code{vignette("auth")} for more details.
+#' @param parse The default, \code{TRUE}, indicates that the result should
+#'   be parsed into a convenient R data structure like a list or data frame. 
+#'   This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+#'   to return the "raw" list produced by the JSON returned from the twitter 
+#'   API.
+#'   
 #' @param users User id or screen name of target user.
-#' @param token Every user should have their own Oauth (Twitter API) token. By
-#'   default \code{token = NULL} this function looks for the path to a saved
-#'   Twitter token via environment variables (which is what `create_token()`
-#'   sets up by default during initial token creation). For instruction on how
-#'   to create a Twitter token see the tokens vignette, i.e.,
-#'   `vignettes("auth", "rtweet")` or see \code{?tokens}.
-#' @param parse Logical, indicating whether or not to parse
-#'   return object into data frame(s).
-#'
 #' @seealso \url{https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-lookup}
+#' 
 #' @examples
 #'
 #' \dontrun{

--- a/man/bearer_token.Rd
+++ b/man/bearer_token.Rd
@@ -7,8 +7,11 @@
 bearer_token(token = NULL)
 }
 \arguments{
-\item{token}{Oauth token created via \code{\link{create_token}}. See details
-for more information on valid tokens.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 A bearer token

--- a/man/direct_messages.Rd
+++ b/man/direct_messages.Rd
@@ -24,15 +24,17 @@ and retrieve, up to a maximum of 50.}
 responses will include a next_cursor value, which can be supplied in
 additional requests to scroll through pages of results.}
 
-\item{parse}{Logical indicating whether to convert response object
-into nested list. Defaults to true.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{since_id}{optional Returns results with an ID greater than
 (that is, more recent than) the specified ID. There are limits to

--- a/man/direct_messages_received.Rd
+++ b/man/direct_messages_received.Rd
@@ -28,15 +28,17 @@ thought of as a limit to the number of Tweets to return because
 suspended or deleted content is removed after the count has been
 applied.}
 
-\item{parse}{Logical indicating whether to convert response object
-into nested list. Defaults to true.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 Return object converted to nested list. If status code of

--- a/man/get_collections.Rd
+++ b/man/get_collections.Rd
@@ -27,15 +27,17 @@ status_id.}
 the next cursor value for any given request--if available--is stored
 as an attribute, accessible via \code{\link{next_cursor}}}
 
-\item{parse}{Logical indicating whether to convert response object
-into nested list. Defaults to true.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 Return object converted to nested list if parsed otherwise

--- a/man/get_favorites.Rd
+++ b/man/get_favorites.Rd
@@ -31,17 +31,17 @@ available.}
 \item{max_id}{Character, returns results with an ID less than (that is,
 older than) or equal to `max_id`.}
 
-\item{parse}{Logical, indicating whether to return parsed vector or
-nested list object. By default, \code{parse = TRUE}
-saves you the time [and frustrations] associated with
-disentangling the Twitter API return objects.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 A tbl data frame of tweets data with users data attribute.

--- a/man/get_followers.Rd
+++ b/man/get_followers.Rd
@@ -41,21 +41,21 @@ limits reset and the desired n is achieved or the number of total
 followers is exhausted. This defaults to FALSE. See details for
 more info regarding possible issues with timing misfires.}
 
-\item{parse}{Logical, indicating whether to return parsed vector or
-nested list object. By default, \code{parse = TRUE}
-saves you the time [and frustrations] associated with
-disentangling the Twitter API return objects.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
 \item{verbose}{Logical indicating whether or not to print messages.
 Only relevant if retryonratelimit = TRUE. Defaults to TRUE,
 prints sleep times and followers gathered counts.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 A tibble data frame of follower IDs (one column named "user_id").

--- a/man/get_friends.Rd
+++ b/man/get_friends.Rd
@@ -45,21 +45,21 @@ results. Other pages specified via cursor values supplied by
 Twitter API response object. This is only relevant if a user has
 over 5000 friends (follows more than 5000 accounts).}
 
-\item{parse}{Logical, indicating whether to return parsed vector or
-nested list object. By default, \code{parse = TRUE}
-saves you the time [and frustrations] associated with
-disentangling the Twitter API return objects.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
 \item{verbose}{Logical indicating whether or not to include output
 messages. Defaults to TRUE, which includes printing a success message
 for each inputted user.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 A tibble data frame with two columns, "user" for name or ID of target

--- a/man/get_mentions.Rd
+++ b/man/get_mentions.Rd
@@ -29,15 +29,17 @@ will be forced to the oldest ID available.}
 \item{max_id}{Character, returns results with an ID less than (that is,
 older than) or equal to `max_id`.}
 
-\item{parse}{Logical indicating whether to convert the response
-object into an R list. Defaults to TRUE.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{...}{Other arguments passed as parameters in composed API
 query.}

--- a/man/get_my_timeline.Rd
+++ b/man/get_my_timeline.Rd
@@ -20,21 +20,21 @@ Must be of length 1 or equal to length of user.}
 \item{max_id}{Character, returns results with an ID less than (that is,
 older than) or equal to \code{max_id}.}
 
-\item{parse}{Logical, indicating whether to return parsed
-(data.frames) or nested list object. By default, \code{parse =
-  TRUE} saves users from the time (and frustrations) associated
-with disentangling the Twitter API return objects.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
 \item{check}{Logical indicating whether to remove check available
 rate limit. Ensures the request does not exceed the maximum
 remaining number of calls.  Defaults to TRUE.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what \code{create_token()}
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-\code{vignettes("auth", "rtweet")} or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{...}{Further arguments passed on as parameters in API query.}
 }

--- a/man/get_retweeters.Rd
+++ b/man/get_retweeters.Rd
@@ -12,15 +12,17 @@ get_retweeters(status_id, n = 100, parse = TRUE, token = NULL)
 \item{n}{Specifies the number of records to retrieve.  Best if
 intervals of 100.}
 
-\item{parse}{Logical indicating whether to convert the response
-object into an R list. Defaults to TRUE.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 data

--- a/man/get_retweets.Rd
+++ b/man/get_retweets.Rd
@@ -12,15 +12,17 @@ get_retweets(status_id, n = 100, parse = TRUE, token = NULL, ...)
 \item{n}{optional Specifies the number of records to retrieve.
 Must be less than or equal to 100.}
 
-\item{parse}{Logical indicating whether to convert the response
-object into an R list. Defaults to TRUE.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{...}{Other arguments used as parameters in the query sent to
 Twitter's rest API, for example, \code{trim_user = TRUE}.}

--- a/man/get_timeline.Rd
+++ b/man/get_timeline.Rd
@@ -44,21 +44,21 @@ or home-timeline. By default, home is set to FALSE, which means
 return a user's home timeline feed, that is, the tweets posted by
 accounts followed by a user, set home to TRUE.}
 
-\item{parse}{Logical, indicating whether to return parsed
-(data.frames) or nested list object. By default, \code{parse =
-TRUE} saves users from the time [and frustrations] associated
-with disentangling the Twitter API return objects.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
 \item{check}{Logical indicating whether to remove check available
 rate limit. Ensures the request does not exceed the maximum
 remaining number of calls.  Defaults to TRUE.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instructions on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{...}{Further arguments passed on as parameters in API query.}
 }

--- a/man/get_trends.Rd
+++ b/man/get_trends.Rd
@@ -35,15 +35,17 @@ function will coerce the second value to longitude.}
 exclude hashtags. Defaults to FALSE--meaning, hashtags are
 included in returned trends.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
 
-\item{parse}{Logical, indicating whether or not to parse return
-trends data. Defaults to true.}
+See \code{vignette("auth")} for more details.}
+
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 }
 \value{
 Tibble data frame of trends data for a given geographical area.

--- a/man/invalidate_bearer.Rd
+++ b/man/invalidate_bearer.Rd
@@ -7,7 +7,11 @@
 invalidate_bearer(token = NULL)
 }
 \arguments{
-\item{token}{Oauth token created via \code{\link{create_token}}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \description{
 Invalidate bearer token

--- a/man/lists_members.Rd
+++ b/man/lists_members.Rd
@@ -49,15 +49,17 @@ value of -1 to begin paging. Provide values as returned in the
 response body's next_cursor and previous_cursor attributes to
 page back and forth in the list.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
 
-\item{parse}{Logical indicating whether to convert the response object into
-an R list. Defaults to TRUE.}
+See \code{vignette("auth")} for more details.}
+
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
 \item{...}{Other arguments used as parameters in query composition.}
 

--- a/man/lists_statuses.Rd
+++ b/man/lists_statuses.Rd
@@ -44,15 +44,17 @@ addition to the standard stream of tweets. The output format of
 retweeted tweets is identical to the representation you see in
 home_timeline.}
 
-\item{parse}{Logical indicating whether to convert the response object into
-an R list. Defaults to TRUE.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 data

--- a/man/lists_subscribers.Rd
+++ b/man/lists_subscribers.Rd
@@ -37,15 +37,17 @@ The response from the API will include a previous_cursor
 and next_cursor to allow paging back and forth. See Using
 cursors to navigate collections for more information.}
 
-\item{parse}{Logical indicating whether to convert the response object into
-an R list. Defaults to TRUE.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \description{
 Get subscribers of a specified list.

--- a/man/lists_subscriptions.Rd
+++ b/man/lists_subscriptions.Rd
@@ -21,15 +21,17 @@ The response from the API will include a previous_cursor
 and next_cursor to allow paging back and forth. See Using
 cursors to navigate collections for more information.}
 
-\item{parse}{Logical indicating whether to convert the response object into
-an R list. Defaults to TRUE.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \description{
 Get list subscriptions of a given user.

--- a/man/lists_users.Rd
+++ b/man/lists_users.Rd
@@ -13,15 +13,17 @@ lists_users(user, reverse = FALSE, token = NULL, parse = TRUE)
 to be returned first. See description above for information on
 how this parameter works.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
 
-\item{parse}{Logical indicating whether to convert the response object into
-an R list. Defaults to TRUE.}
+See \code{vignette("auth")} for more details.}
+
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 }
 \value{
 data

--- a/man/lookup_collections.Rd
+++ b/man/lookup_collections.Rd
@@ -13,15 +13,17 @@ e.g., "custom-539487832448843776"}
 \item{n}{Specifies the maximum number of results to include in
 the response. Specify count between 1 and 200.}
 
-\item{parse}{Logical indicating whether to convert response object into
-nested list. Defaults to true.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{...}{Other arguments passed along to composed request query.}
 }

--- a/man/lookup_friendships.Rd
+++ b/man/lookup_friendships.Rd
@@ -11,15 +11,17 @@ lookup_friendships(source, target, parse = TRUE, token = NULL)
 
 \item{target}{Screen name or user id of target user.}
 
-\item{parse}{Logical indicating whether to return parsed data frame.
-Defaults to true.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 Data frame converted form returned JSON object. If parse is

--- a/man/lookup_statuses.Rd
+++ b/man/lookup_statuses.Rd
@@ -12,15 +12,17 @@ lookup_tweets(statuses, parse = TRUE, token = NULL)
 \arguments{
 \item{statuses}{User id or screen name of target user.}
 
-\item{parse}{Logical, indicating whether or not to parse
-return object into data frame(s).}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 A tibble of tweets data.

--- a/man/lookup_users.Rd
+++ b/man/lookup_users.Rd
@@ -9,15 +9,17 @@ lookup_users(users, parse = TRUE, token = NULL)
 \arguments{
 \item{users}{User id or screen name of target user.}
 
-\item{parse}{Logical, indicating whether or not to parse
-return object into data frame(s).}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 A tibble of users data.

--- a/man/my_friendships.Rd
+++ b/man/my_friendships.Rd
@@ -9,13 +9,17 @@ my_friendships(user, parse = TRUE, token = NULL)
 \arguments{
 \item{user}{Screen name or user id of target user.}
 
-\item{parse}{Logical indicating whether to return parsed data frame.
-Defaults to true.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{OAuth token. By default \code{token = NULL} fetches a
-non-exhausted token from an environment variable. Find instructions
-on how to create tokens and setup an environment variable in the
-tokens vignette (in r, send \code{?tokens} to console).}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 Data frame converted form returned JSON object. If parse is

--- a/man/post_favorite.Rd
+++ b/man/post_favorite.Rd
@@ -22,9 +22,11 @@ remove (delete) target tweet as favorite.}
 \item{include_entities}{Logical indicating whether to
 include entities object in return.}
 
-\item{token}{OAuth token. By default \code{token = NULL}
-fetches a non-exhausted token from an environment
-variable tokens.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \description{
 Favorites target status id.

--- a/man/post_follow.Rd
+++ b/man/post_follow.Rd
@@ -38,9 +38,11 @@ for target user. Defaults to false.}
 \item{retweets}{Logical indicating whether to enable retweets
 for target user. Defaults to true.}
 
-\item{token}{OAuth token. By default \code{token = NULL}
-fetches a non-exhausted token from an environment
-variable tokens.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \description{
 Follows target twitter user.

--- a/man/post_friendship.Rd
+++ b/man/post_friendship.Rd
@@ -17,9 +17,11 @@ to false.}
 \item{retweets}{Logical indicating whether to enable or disable
 retweets from target user behaviors. Defaults to false.}
 
-\item{token}{OAuth token. By default \code{token = NULL}
-fetches a non-exhausted token from an environment
-variable tokens.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \description{
 Updates friendship notifications and retweet abilities.

--- a/man/post_list.Rd
+++ b/man/post_list.Rd
@@ -33,8 +33,11 @@ already exists.}
 
 \item{slug}{Optional, list slug.}
 
-\item{token}{OAuth token associated with user who owns [or will own] the list
-of interest. Token must have write permissions!}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 Response object from HTTP request.

--- a/man/post_message.Rd
+++ b/man/post_message.Rd
@@ -14,9 +14,11 @@ post_message(text, user, media = NULL, token = NULL)
 \item{media}{File path to image or video media to be
 included in tweet.}
 
-\item{token}{OAuth token. By default \code{token = NULL}
-fetches a non-exhausted token from an environment
-variable tokens.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \description{
 Posts direct message from user's Twitter account

--- a/man/post_tweet.Rd
+++ b/man/post_tweet.Rd
@@ -23,8 +23,11 @@ post_tweet(
 up-to length 4 character vector with file paths to static images to be included in tweet.
 **The caller is responsible for managing this.**}
 
-\item{token}{OAuth token. By default \code{token = NULL} fetches a
-non-exhausted token from an environment variable tokens.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{in_reply_to_status_id}{Status ID of tweet to which you'd like to reply.
 Note: in line with the Twitter API, this parameter is ignored unless the

--- a/man/rate_limit.Rd
+++ b/man/rate_limit.Rd
@@ -10,11 +10,11 @@ rate_limit(token = NULL, query = NULL, parse = TRUE)
 rate_limits(token = NULL, query = NULL, parse = TRUE)
 }
 \arguments{
-\item{token}{One or more OAuth tokens. By default token = NULL
-fetches a non-exhausted token from an environment variable. Find
-instructions on how to create tokens and setup an environment
-variable in the tokens vignette (in r, send \code{?tokens} to
-console).}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{query}{Specific API (path) or a character function name,
 e.g., query = "get_timeline", used to subset the returned data.
@@ -26,8 +26,11 @@ returns remaining limit for user lookup requests; type =
 type = "friends/ids" returns remaining limit for friend id
 requests.}
 
-\item{parse}{Logical indicating whether to parse response object
-into a data frame.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 }
 \value{
 Tibble data frame with rate limit information pertaining to

--- a/man/search_30day.Rd
+++ b/man/search_30day.Rd
@@ -36,11 +36,17 @@ saved. If the directory doesn't exist, it will be created. If NULL (the
 default) then a dir will be created in the current working directory. To
 override/deactivate safedir set this to FALSE.}
 
-\item{parse}{Logical indicating whether to convert data into data frame.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{A token associated with a user-created APP (requires a developer
-account), which is converted to a bearer token in order to make premium
-API requests}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 A tibble data frame of Twitter data

--- a/man/search_fullarchive.Rd
+++ b/man/search_fullarchive.Rd
@@ -36,11 +36,17 @@ saved. If the directory doesn't exist, it will be created. If NULL (the
 default) then a dir will be created in the current working directory. To
 override/deactivate safedir set this to FALSE.}
 
-\item{parse}{Logical indicating whether to convert data into data frame.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{A token associated with a user-created APP (requires a developer
-account), which is converted to a bearer token in order to make premium
-API requests}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 }
 \value{
 A tibble data frame of Twitter data

--- a/man/search_tweets.Rd
+++ b/man/search_tweets.Rd
@@ -88,26 +88,17 @@ leverage \code{retryonratelimit} for sets of tweets and
 \code{max_id} to allow results to continue where previous efforts
 left off.}
 
-\item{parse}{Logical, indicating whether to return parsed
-data.frame, if true, or nested list, if false. By default,
-\code{parse = TRUE} saves users from the wreck of time and
-frustration associated with disentangling the nasty nested list
-returned from Twitter's API. As Twitter's APIs are subject to
-change, this argument would be especially useful when changes to
-Twitter's APIs affect performance of internal parsers. Setting
-\code{parse = FALSE} also ensures the maximum amount of possible
-information is returned. By default, the rtweet parse process
-returns nearly all bits of information returned from
-Twitter. However, users may occasionally encounter new or
-omitted variables. In these rare cases, the nested list object
-will be the only way to access these variables.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{retryonratelimit}{Logical indicating whether to wait and
 retry when rate limited. This argument is only relevant if the

--- a/man/search_users.Rd
+++ b/man/search_users.Rd
@@ -26,17 +26,17 @@ phrases as is allowed by \code{search_tweets}.}
 return. Defaults to 100. Maximum number of users returned from a
 single search is 1,000.}
 
-\item{parse}{Logical, indicating whether to return parsed
-(data.frames) or nested list object. By default,
-\code{parse = TRUE} saves users from the time [and frustrations]
-associated with disentangling the Twitter API return objects.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{verbose}{Logical, indicating whether or not to output
 processing/retrieval messages.}

--- a/man/stream_tweets.Rd
+++ b/man/stream_tweets.Rd
@@ -34,23 +34,17 @@ tweets.  By default, this is set to 30 seconds. To stream
 indefinitely, use \code{timeout = FALSE} to ensure JSON file is
 not deleted upon completion or \code{timeout = Inf}.}
 
-\item{parse}{Logical, indicating whether to return parsed data.  By
-default, \code{parse = TRUE}, this function does the parsing for
-you. However, for larger streams, or for automated scripts
-designed to continuously collect data, this should be set to
-false as the parsing process can eat up processing resources and
-time. For other uses, setting parse to TRUE saves you from having
-to sort and parse the messy list structure returned by
-Twitter. (Note: if you set parse to false, you can use the
-\code{\link{parse_stream}} function to parse the JSON file at a
-later point in time.)}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{file_name}{Character with name of file. By default, a
 temporary file is created, tweets are parsed and returned to

--- a/man/suggested_users.Rd
+++ b/man/suggested_users.Rd
@@ -17,17 +17,19 @@ suggested_users_all(slugs = NULL, parse = TRUE, token = NULL)
 requested language. The language must be specified by the
 appropriate two letter ISO 639-1 representation.}
 
-\item{token}{Every user should have their own Oauth (Twitter API) token. By
-default \code{token = NULL} this function looks for the path to a saved
-Twitter token via environment variables (which is what `create_token()`
-sets up by default during initial token creation). For instruction on how
-to create a Twitter token see the tokens vignette, i.e.,
-`vignettes("auth", "rtweet")` or see \code{?tokens}.}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
+
+See \code{vignette("auth")} for more details.}
 
 \item{slug}{required The short name of list or a category}
 
-\item{parse}{Logical indicating whether to parse the returned data into
-a tibble data frame. See details for more on the returned users data.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 
 \item{slugs}{Optional, one or more slugs returned by
 \code{\link{suggested_slugs}}. API rate limits this to 15 max (function

--- a/man/trends_available.Rd
+++ b/man/trends_available.Rd
@@ -7,16 +7,17 @@
 trends_available(token = NULL, parse = TRUE)
 }
 \arguments{
-\item{token}{OAuth token. By default \code{token = NULL} fetches a
-non-exhausted token from an environment variable. Find instructions
-on how to create tokens and setup an environment variable in the
-tokens vignette (in r, send \code{?tokens} to console).}
+\item{token}{An OAuth token object. The default, \code{NULL}, will retrieve
+a default token with \code{\link{get_token}()}. You should only need to 
+use this argument if you are wrapping rtweet in a package. 
 
-\item{parse}{Logical, indicating whether to return parsed
-(data.frames) or nested list object. By default,
-\code{parse = TRUE} saves users from the time
-[and frustrations] associated with disentangling the Twitter
-API return objects.}
+See \code{vignette("auth")} for more details.}
+
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame. 
+This protects you from the vagaries of the twitter API. Use \code{FALSE} 
+to return the "raw" list produced by the JSON returned from the twitter 
+API.}
 }
 \value{
 Data frame with WOEID column. WOEID is a Yahoo! Where On


### PR DESCRIPTION
Starting with token and parse arguments

@llrs please take a look at the new docs found in `lookup_users()` and let me know if there's anything I could to make the documentation more clear. 

Once this is merged, I can convert all the docs to use markdown.