### PR TITLE
Convert to testthat 3e

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,10 +39,11 @@ Suggests:
     openssl,
     readr,
     rmarkdown,
-    testthat (>= 2.1.0),
+    testthat (>= 3.0.0),
     webshot,
     covr,
     igraph
 VignetteBuilder: knitr
 LazyData: yes
 RoxygenNote: 7.1.1
+Config/testthat/edition: 3

--- a/tests/testthat/test_access_level.R
+++ b/tests/testthat/test_access_level.R
@@ -1,5 +1,3 @@
-context("test-access-level")
-
 test_that("api_access_level works", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_bearer.R
+++ b/tests/testthat/test_bearer.R
@@ -1,5 +1,3 @@
-context("bearer_token")
-
 test_that("bearer_token functions", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_collections.R
+++ b/tests/testthat/test_collections.R
@@ -1,6 +1,3 @@
-
-context("lookup_collections")
-
 test_that("lookup_collections returns tweets data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_direct_messages.R
+++ b/tests/testthat/test_direct_messages.R
@@ -1,5 +1,3 @@
-context("direct_messages")
-
 test_that("direct_messages functions", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_friendships.R
+++ b/tests/testthat/test_friendships.R
@@ -1,6 +1,3 @@
-
-context("friendships")
-
 test_that("friendships returns data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_get_favorites.R
+++ b/tests/testthat/test_get_favorites.R
@@ -1,5 +1,3 @@
-context("get_favorites")
-
 test_that("get_favorites returns tweets data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_get_followers.R
+++ b/tests/testthat/test_get_followers.R
@@ -1,5 +1,3 @@
-context("get_followers")
-
 test_that("get_followers returns data frame with user_id", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_get_friends.R
+++ b/tests/testthat/test_get_friends.R
@@ -1,5 +1,3 @@
-context("get_friends")
-
 test_that("get_friends returns data frame with ids", {
     skip_on_cran()
     skip_if_offline()

--- a/tests/testthat/test_get_my_timeline.R
+++ b/tests/testthat/test_get_my_timeline.R
@@ -1,5 +1,3 @@
-context("get_my_timeline")
-
 test_that("get_my_timeline", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_get_timelines.R
+++ b/tests/testthat/test_get_timelines.R
@@ -1,5 +1,3 @@
-context("get_timeline")
-
 test_that("get_timeline", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_get_trends.R
+++ b/tests/testthat/test_get_trends.R
@@ -1,6 +1,3 @@
-context("get_trends")
-
-
 test_that("get_trends returns trends data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_get_trends_closest.R
+++ b/tests/testthat/test_get_trends_closest.R
@@ -1,5 +1,3 @@
-context("trends_available")
-
 test_that("get_trends_closest returns data frame with correct city name", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_graph.R
+++ b/tests/testthat/test_graph.R
@@ -1,5 +1,3 @@
-context("network_data")
-
 test_that("graphing functions work", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_lists_funs.R
+++ b/tests/testthat/test_lists_funs.R
@@ -1,7 +1,3 @@
-## TEST LISTS FUNCTIONS
-
-context("lists")
-
 test_that("lists_users returns data frame with nrow > 1", {
     skip_on_cran()
     skip_if_offline()

--- a/tests/testthat/test_lookup_coords.R
+++ b/tests/testthat/test_lookup_coords.R
@@ -1,6 +1,3 @@
-
-context("lookup_coords")
-
 test_that("lookup_coords returns coords data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_lookup_statuses.R
+++ b/tests/testthat/test_lookup_statuses.R
@@ -1,5 +1,3 @@
-context("lookup_statuses")
-
 test_that("lookup_statuses returns users data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_lookup_users.R
+++ b/tests/testthat/test_lookup_users.R
@@ -1,5 +1,3 @@
-context("lookup_users")
-
 test_that("lookup_users returns users data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_mentions.R
+++ b/tests/testthat/test_mentions.R
@@ -1,5 +1,3 @@
-context("mentions")
-
 test_that("mentions returns tweets data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_plain_tweets.R
+++ b/tests/testthat/test_plain_tweets.R
@@ -1,5 +1,3 @@
-context("plain_tweets")
-
 test_that("plain_tweets functions", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_rate_limit.R
+++ b/tests/testthat/test_rate_limit.R
@@ -1,5 +1,3 @@
-context("rate_limit")
-
 test_that("rate_limit returns rate_limit data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_retweets.R
+++ b/tests/testthat/test_retweets.R
@@ -1,6 +1,3 @@
-
-context("retweets")
-
 test_that("get_retweets returns tweets data", {
   skip_on_cran()
   skip("requires kearneymw as twitter auth")

--- a/tests/testthat/test_save_as_csv.R
+++ b/tests/testthat/test_save_as_csv.R
@@ -1,5 +1,3 @@
-context("save_as_csv")
-
 test_that("save_as_csv saves tweets data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_search_tweets.R
+++ b/tests/testthat/test_search_tweets.R
@@ -1,5 +1,3 @@
-context("search_tweets")
-
 test_that("search_tweets returns tweets data and latlng", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_search_users.R
+++ b/tests/testthat/test_search_users.R
@@ -1,5 +1,3 @@
-context("search_users")
-
 test_that("search_users returns users data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_stream_tweets.R
+++ b/tests/testthat/test_stream_tweets.R
@@ -1,5 +1,3 @@
-context("stream_tweets")
-
 test_that("stream_tweets returns tweets data", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_tokens.R
+++ b/tests/testthat/test_tokens.R
@@ -1,5 +1,3 @@
-context("system_token")
-
 test_that("system_token functions", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_trends_available.R
+++ b/tests/testthat/test_trends_available.R
@@ -1,5 +1,3 @@
-context("trends_available")
-
 test_that("trends_available returns data frame", {
 	skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_tweet_shot.R
+++ b/tests/testthat/test_tweet_shot.R
@@ -1,5 +1,3 @@
-context("tweet_shot")
-
 test_that("tweet_shot", {
   skip_on_cran()
   skip_if_offline()

--- a/tests/testthat/test_username.R
+++ b/tests/testthat/test_username.R
@@ -1,5 +1,3 @@
-context("test-test_username-r")
-
 test_that("test authenticating user name", {
   skip_on_cran()
   skip_if_offline()


### PR DESCRIPTION
This just amounted to removing all the context() calls

The primary advantages are improved `expect_equal()` failures, and the ability to use snapshot tests.