### PR TITLE
Don't attach package in try_require()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -476,7 +476,6 @@ try_require <- function(pkg, f = NULL) {
   }
 
   if (requireNamespace(pkg, quietly = TRUE)) {
-    library(pkg, character.only = TRUE)
     return(invisible())
   }
 


### PR DESCRIPTION
Because there's no need, and generally packages shouldn't change the user's search path.