### PR TITLE
Improve the maximum n warnings

### DIFF
--- a/R/favorites.R
+++ b/R/favorites.R
@@ -142,9 +142,7 @@ get_favorites_ <- function(user,
                            token = NULL) {
   query <- "favorites/list"
   if (n > 3000) {
-    warning(paste0("n exceeds max favs returned per ",
-      "token. Setting n to 3000..."),
-      call. = FALSE)
+    warning("n is set to 3000 instead, which is the maximum"))
     n <- 3000
     count <- 200
   } else if (n < 200) {

--- a/R/lists_members.R
+++ b/R/lists_members.R
@@ -50,7 +50,7 @@ lists_members <- function(list_id = NULL,
                           ...) {
   stopifnot(is.numeric(n))
   if (n > 5000) {
-    warning("maximum number of list users it 5,000")
+    warning("n is set to 5000 instead, which is the maximum")
     n <- 5000
   }
   

--- a/R/lists_memberships.R
+++ b/R/lists_memberships.R
@@ -91,7 +91,7 @@ lists_memberships_call <- function(user,
 
   stopifnot(is.atomic(user), is_n(n))
   if (n > 1000) {
-    warning("n is too large. set to max (1000) instead", call. = FALSE)
+    warning("n is set to 1000 instead, which is the maximum")
     n <- 1000
   }
   if (!filter_to_owned_lists && identical(user, "")) {

--- a/R/search_users.R
+++ b/R/search_users.R
@@ -65,9 +65,7 @@ search_users_call <- function(q, n = 20,
   stopifnot(is_n(n), is.atomic(q))
   token <- check_token(token)
   if (n > 1000) {
-    warning(
-      paste0("search only returns up to 1,000 users per ",
-        "unique search. Setting n to 1000..."))
+    warning("n is set to 1000 instead, which is the maximum")
     n <- 1000
   }
   n.times <- ceiling(n / 20)


### PR DESCRIPTION
This pull request improves the maximum n warnings, making them consistent with each other. One of these warnings had a typo. All four warnings had been written in different ways.