### PR TITLE
Add geolocation feature to post_tweet

### DIFF
--- a/R/post-tweet.R
+++ b/R/post-tweet.R
@@ -120,6 +120,8 @@ post_tweet <- function(status = "my first rtweet #rstats",
   
   ## geotag if provided
   if (!is.null(lat) && !is.null(long)) {
+    stopifnot("lat should be between -90 and 90 degrees" ~ abs(lat) <= 90)
+    stopifnot("long should be between -180 and 180  degrees" ~ abs(long) <= 180)
     params[["lat"]] <- as.double(lat)
     params[["long"]] <- as.double(long)
   

--- a/R/post-tweet.R
+++ b/R/post-tweet.R
@@ -23,6 +23,12 @@
 #'        `media` (i.e. as many alt text entries as there are `media` entries). See
 #'        [the official API documentation](https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-metadata-create)
 #'        for more information.
+#' @param lat Latitude of the location the tweet refers to. Range should be
+#'   between -90 and 90 (north).
+#' @param long Longitude of the location the tweet refers to. Range should be
+#'   between -180 and 180 (west).
+#' @param display_coordinates Put a pin on the exact coordinates a tweet has
+#'   been sent from.
 #' @examples
 #' \dontrun{
 #' ## generate data to make/save plot (as a .png file)
@@ -72,7 +78,10 @@ post_tweet <- function(status = "my first rtweet #rstats",
                        destroy_id = NULL,
                        retweet_id = NULL,
                        auto_populate_reply_metadata = FALSE,
-                       media_alt_text = NULL) {
+                       media_alt_text = NULL,
+                       lat = NULL,
+                       long = NULL,
+                       display_coordinates = FALSE) {
 
   ## if delete
   if (!is.null(destroy_id)) {
@@ -107,6 +116,18 @@ post_tweet <- function(status = "my first rtweet #rstats",
     params <- list(
       status = status
     )
+  }
+  
+  ## geotag if provided
+  if (!is.null(lat) && !is.null(long)) {
+    params[["lat"]] <- as.double(lat)
+    params[["long"]] <- as.double(long)
+  
+    if (isTRUE(display_coordinates)) {
+      params[["display_coordinates"]] <- "true"
+    } else {
+      params[["display_coordinates"]] <- "false"
+    }
   }
 
   if (!is.null(in_reply_to_status_id)) {

--- a/R/post-tweet.R
+++ b/R/post-tweet.R
@@ -23,12 +23,17 @@
 #'        `media` (i.e. as many alt text entries as there are `media` entries). See
 #'        [the official API documentation](https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-metadata-create)
 #'        for more information.
-#' @param lat Latitude of the location the tweet refers to. Range should be
-#'   between -90 and 90 (north).
-#' @param long Longitude of the location the tweet refers to. Range should be
-#'   between -180 and 180 (west).
+#' @param lat A numeric value representing the latitude of the location the 
+#'   tweet refers to. Range should be between -90 and 90 (north). Note that you
+#'   should enable the "Precise location" option in your account via *Settings 
+#'   and privacy > Privacy and Safety > Location*. See 
+#'   [the official Help Center section](https://help.twitter.com/en/safety-and-security/twitter-location-services-for-mobile). 
+#' @param long A numeric value representing the longitude of the location the 
+#'   tweet refers to. Range should be between -180 and 180 (west). See
+#'   `lat` parameter.
 #' @param display_coordinates Put a pin on the exact coordinates a tweet has
-#'   been sent from.
+#'   been sent from. Value should be TRUE or FALSE. This parameter would apply 
+#'   only if you have provided a valid `lat/long` pair of valid values. 
 #' @examples
 #' \dontrun{
 #' ## generate data to make/save plot (as a .png file)
@@ -120,12 +125,21 @@ post_tweet <- function(status = "my first rtweet #rstats",
   
   ## geotag if provided
   if (!is.null(lat) && !is.null(long)) {
-    stopifnot("lat should be between -90 and 90 degrees" ~ abs(lat) <= 90)
-    stopifnot("long should be between -180 and 180  degrees" ~ abs(long) <= 180)
+    # Validate inputs
+    if (!is.numeric(lat)) stop("lat should be numeric")
+    if (!is.numeric(long)) stop("long should be numeric")
+    
+    if (!is.logical(display_coordinates)) {
+      stop("display_coordinates should be TRUE/FALSE")
+    }
+    
+    if (abs(lat) > 90) stop("lat should be between -90 and 90 degrees")
+    if (abs(long) > 180) stop("long should be between -180 and 180  degrees")
+    
     params[["lat"]] <- as.double(lat)
     params[["long"]] <- as.double(long)
-  
-    if (isTRUE(display_coordinates)) {
+    
+    if (display_coordinates) {
       params[["display_coordinates"]] <- "true"
     } else {
       params[["display_coordinates"]] <- "false"

--- a/man/post_tweet.Rd
+++ b/man/post_tweet.Rd
@@ -55,14 +55,19 @@ metadata to the \code{media} you are uploading. Should be same length as
 \href{https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-metadata-create}{the official API documentation}
 for more information.}
 
-\item{lat}{Latitude of the location the tweet refers to. Range should be
-between -90 and 90 (north).}
+\item{lat}{A numeric value representing the latitude of the location the
+tweet refers to. Range should be between -90 and 90 (north). Note that you
+should enable the "Precise location" option in your account via \emph{Settings
+and privacy > Privacy and Safety > Location}. See
+\href{https://help.twitter.com/en/safety-and-security/twitter-location-services-for-mobile}{the official Help Center section}.}
 
-\item{long}{Longitude of the location the tweet refers to. Range should be
-between -180 and 180 (west).}
+\item{long}{A numeric value representing the longitude of the location the
+tweet refers to. Range should be between -180 and 180 (west). See
+\code{lat} parameter.}
 
 \item{display_coordinates}{Put a pin on the exact coordinates a tweet has
-been sent from.}
+been sent from. Value should be TRUE or FALSE. This parameter would apply
+only if you have provided a valid \code{lat/long} pair of valid values.}
 }
 \description{
 Posts status update to user's Twitter account

--- a/man/post_tweet.Rd
+++ b/man/post_tweet.Rd
@@ -13,7 +13,10 @@ post_tweet(
   destroy_id = NULL,
   retweet_id = NULL,
   auto_populate_reply_metadata = FALSE,
-  media_alt_text = NULL
+  media_alt_text = NULL,
+  lat = NULL,
+  long = NULL,
+  display_coordinates = FALSE
 )
 }
 \arguments{
@@ -51,6 +54,15 @@ metadata to the \code{media} you are uploading. Should be same length as
 \code{media} (i.e. as many alt text entries as there are \code{media} entries). See
 \href{https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-metadata-create}{the official API documentation}
 for more information.}
+
+\item{lat}{Latitude of the location the tweet refers to. Range should be
+between -90 and 90 (north).}
+
+\item{long}{Longitude of the location the tweet refers to. Range should be
+between -180 and 180 (west).}
+
+\item{display_coordinates}{Put a pin on the exact coordinates a tweet has
+been sent from.}
 }
 \description{
 Posts status update to user's Twitter account

--- a/tests/testthat/test-post-tweet.R
+++ b/tests/testthat/test-post-tweet.R
@@ -31,6 +31,14 @@ test_that("post_tweet works", {
 })
 
 test_that("post_tweet geolocated works", {
+  # Test errors
+  msg <- paste("test geolocated error", Sys.time()) # To avoid having duplicated status
+  expect_error(post_tweet(msg, lat = "x", long = 0))
+  expect_error(post_tweet(msg, lat = 0, long = "x"))
+  expect_error(post_tweet(msg, lat = 91, long = 0))
+  expect_error(post_tweet(msg, lat = 0, long = 181))
+  expect_error(post_tweet(msg, lat = 0, long = 0, display_coordinates = "error"))
+  
   # Test geolocated tweet
   msg <- paste("test geolocated", Sys.time()) # To avoid having duplicated status
   rt <- expect_message(post_tweet(msg, lat = -36.811784, long = 174.792657), "your tweet has been posted!")

--- a/tests/testthat/test-post-tweet.R
+++ b/tests/testthat/test-post-tweet.R
@@ -29,3 +29,19 @@ test_that("post_tweet works", {
   rt <- expect_message(post_destroy(crt$id_str), "your tweet has been deleted!")
   expect_equal(httr::status_code(rt), 200L)
 })
+
+test_that("post_tweet geolocated works", {
+  # Test geolocated tweet
+  msg <- paste("test geolocated", Sys.time()) # To avoid having duplicated status
+  rt <- expect_message(post_tweet(msg, lat = -36.811784, long = 174.792657), "your tweet has been posted!")
+  crt <- httr::content(rt)
+  rt <- expect_message(post_destroy(crt$id_str), "your tweet has been deleted!")
+  expect_equal(httr::status_code(rt), 200L)
+
+  # Test display_coordinates param
+  msg <- paste("test geolocated", Sys.time()) # To avoid having duplicated status
+  rt <- expect_message(post_tweet(msg, lat = -36.811784, long = 174.792657, display_coordinates = TRUE), "your tweet has been posted!")
+  crt <- httr::content(rt)
+  rt <- expect_message(post_destroy(crt$id_str), "your tweet has been deleted!")
+  expect_equal(httr::status_code(rt), 200L)
+})


### PR DESCRIPTION
closes #501 

I think this is ready for review, full API specification on:

https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update