### PR TITLE
Standardize DESCRIPTION URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Description: An implementation of calls designed to collect and
     Program Interfaces (API), which can be found at the following URL:
     <https://developer.twitter.com/en/docs>.
 License: MIT + file LICENSE
-URL: https://docs.ropensci.org/rtweet
+URL: https://docs.ropensci.org/rtweet,
+    https://github.com/ropensci/rtweet
 BugReports: https://github.com/ropensci/rtweet/issues
 Depends:
     R (>= 3.5.0)


### PR DESCRIPTION
This is more typical of what we do in tidyverse / r-lib and, as a result, works better with usethis's `browse_*()` functions.