### PR TITLE
Remove api_access_level

### DIFF
--- a/R/access_level.R
+++ b/R/access_level.R
@@ -1,9 +1,0 @@
-api_access_level <- function(token = NULL) {
-  r <- TWIT_get(token, "/1.1/account/settings", parse = FALSE)
-
-  if ("headers" %in% names(r) && "x-access-level" %in% names(r$headers)) {
-    r$headers$`x-access-level`
-  } else {
-    r
-  }
-}

--- a/R/direct_messages.R
+++ b/R/direct_messages.R
@@ -32,11 +32,6 @@ direct_messages <- function(n = 50,
                             next_cursor = NULL,
                             parse = TRUE,
                             token = NULL) {
-  if (!identical(api_access_level(token), "read-write-directmessages")) {
-    stop("Token does not have `read-write-directmessages` access level. ",
-      "For DM permissions, users must create their own app at developer.twitter.com")
-  }
-  
   params <- list(
     count = n, 
     next_cursor = next_cursor

--- a/tests/testthat/test-access_level.R
+++ b/tests/testthat/test-access_level.R
@@ -1,4 +1,0 @@
-test_that("api_access_level works", {
-  a <- api_access_level()
-  expect_true(is.character(a) && length(a) == 1)
-})


### PR DESCRIPTION
I realised that this is no longer needed because TWIT_get() will automatically surface the error from the Twitter API.