### PR TITLE
Standardise documentation for pagination parameters

### DIFF
--- a/R/direct_messages.R
+++ b/R/direct_messages.R
@@ -6,7 +6,6 @@
 #' about the sender and recipient. 
 #'
 #' @inheritParams TWIT_paginate_cursor
-#' @inheritParams lookup_users
 #' @param next_cursor `r lifecycle::badge("deprecated")` Use `cursor` instead.
 #' @return A list with one element for each page of results.
 #' @examples

--- a/R/direct_messages.R
+++ b/R/direct_messages.R
@@ -49,11 +49,6 @@ direct_messages <- function(n = 50,
 #' by the authenticating (home) user. This function requires access
 #' token with read, write, and direct messages access.
 #'
-#' @param n optional Specifies the number of direct messages to try
-#'   and retrieve, up to a maximum of 200. The value of count is best
-#'   thought of as a limit to the number of Tweets to return because
-#'   suspended or deleted content is removed after the count has been
-#'   applied.
 #' @return Return object converted to nested list. If status code of
 #'   response object is not 200, the response object is returned
 #'   directly.

--- a/R/direct_messages.R
+++ b/R/direct_messages.R
@@ -50,19 +50,11 @@ direct_messages <- function(n = 50,
 #' by the authenticating (home) user. This function requires access
 #' token with read, write, and direct messages access.
 #'
-#' @param since_id optional Returns results with an ID greater than
-#'   (that is, more recent than) the specified ID. There are limits to
-#'   the number of Tweets which can be accessed through the API. If
-#'   the limit of Tweets has occurred since the since_id, the since_id
-#'   will be forced to the oldest ID available.
-#' @param max_id Character, returns results with an ID less than (that is,
-#'   older than) or equal to `max_id`.
 #' @param n optional Specifies the number of direct messages to try
 #'   and retrieve, up to a maximum of 200. The value of count is best
 #'   thought of as a limit to the number of Tweets to return because
 #'   suspended or deleted content is removed after the count has been
 #'   applied.
-#' @inheritParams lookup_users
 #' @return Return object converted to nested list. If status code of
 #'   response object is not 200, the response object is returned
 #'   directly.
@@ -99,9 +91,8 @@ direct_messages_received <- function(since_id = NULL,
     "Please use `direct_messages()` instead.")
 }
 
-#' @inheritParams direct_messages_received
 #' @export
-#' @rdname direct_messages
+#' @rdname direct_messages_received
 direct_messages_sent <- function(since_id = NULL,
                                  max_id = NULL,
                                  n = 200,

--- a/R/favorites.R
+++ b/R/favorites.R
@@ -3,6 +3,7 @@
 #' Returns up to 3,000 statuses favorited by each of one or more
 #' specific Twitter users.
 #'
+#' @inheritParams TWIT_paginate_max_id
 #' @inheritParams get_timeline
 #' @param n Specifies the number of records to retrieve. Defaults to 200,
 #'   which is the maximum number of records that can be retrieved in a single
@@ -10,10 +11,6 @@
 #'   
 #'   `n` is applied before removing any tweets that have been suspended or 
 #'    deleted. 
-#' @param since_id,max_id Limit tweets to ids in `(since_id, max_id]`.
-#'   If `since_id` is smaller than the earliest tweet available to the API,
-#'   it will be forced to the oldest tweet available.
-#' @inheritParams lookup_users
 #' @return A tibble with one row for each tweet.
 #' @examples
 #' \dontrun{
@@ -62,14 +59,14 @@ get_favorites_user <- function(user,
 
   params <- list(
     tweet_mode = "extended",
-    include_ext_alt_text = "true",
-    since_id = since_id
+    include_ext_alt_text = "true"
   )
   params[[user_type(user)]] <- user
   
   results <- TWIT_paginate_max_id(token, "/1.1/favorites/list", params,
     page_size = 200,
     max_id = max_id,
+    since_id = since_id,
     n = n,
     parse = parse
   )

--- a/R/favorites.R
+++ b/R/favorites.R
@@ -5,12 +5,6 @@
 #'
 #' @inheritParams TWIT_paginate_max_id
 #' @inheritParams get_timeline
-#' @param n Specifies the number of records to retrieve. Defaults to 200,
-#'   which is the maximum number of records that can be retrieved in a single
-#'   request. Higher numbers will require multiple requests.
-#'   
-#'   `n` is applied before removing any tweets that have been suspended or 
-#'    deleted. 
 #' @return A tibble with one row for each tweet.
 #' @examples
 #' \dontrun{

--- a/R/followers.R
+++ b/R/followers.R
@@ -3,8 +3,8 @@
 #' Returns a list of user IDs for the accounts following specified
 #' user.
 #'
-#' @inheritParams get_timeline
 #' @inheritParams TWIT_paginate_cursor
+#' @inheritParams get_timeline
 #' @param n Number of followers to return. Use `Inf` to download all followers.
 #' 
 #'   Results are downloaded in pages of 5000, and you can download 15 pages

--- a/R/followers.R
+++ b/R/followers.R
@@ -5,11 +5,6 @@
 #'
 #' @inheritParams TWIT_paginate_cursor
 #' @inheritParams get_timeline
-#' @param n Number of followers to return. Use `Inf` to download all followers.
-#' 
-#'   Results are downloaded in pages of 5000, and you can download 15 pages
-#'   (i.e. 75,000 tweets) in each 15 minute period. The easiest way to download 
-#'   more than that is to set `retryonratelimit = TRUE`.
 #' @param page `r lifecycle::badge("deprecated")` Please use `cursor` instead.
 #' @seealso
 #'   <https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids>

--- a/R/friends.R
+++ b/R/friends.R
@@ -3,7 +3,7 @@
 #' Returns a list of user IDs for the accounts following BY one or
 #' more specified users.
 #'
-#' @inheritParams lookup_users
+#' @inheritParams TWIT_paginate_cursor
 #' @inheritParams get_followers
 #' @param users Screen name or user ID of target user from which the
 #'   user IDs of friends (accounts followed BY target user) will be

--- a/R/friends.R
+++ b/R/friends.R
@@ -1,25 +1,17 @@
 #' Get user IDs of accounts followed by target user(s).
 #'
 #' Returns a list of user IDs for the accounts following BY one or
-#' more specified users.
+#' more specified users. 
+#' 
+#' Generally, you should not need to set `n` to more than 5,000 since Twitter
+#' limits the number of people that you can follow (i.e. to follow more than
+#' 5,000 people at least 5,000 people need to follow you).
 #'
 #' @inheritParams TWIT_paginate_cursor
 #' @inheritParams get_followers
 #' @param users Screen name or user ID of target user from which the
 #'   user IDs of friends (accounts followed BY target user) will be
 #'   retrieved.
-#' @param n Number of friends (user IDs) to return. Defaults to 5,000,
-#'   which is the maximum returned by a single API call. Users are
-#'   limited to 15 of these requests per 15 minutes. Twitter limits
-#'   the number of friends a user can have to 5,000. To follow more
-#'   than 5,000 accounts (to have more than 5 thousand "friends")
-#'   accounts must meet certain requirements (e.g., a certain ratio of
-#'   followers to friends). Consequently, the vast majority of users
-#'   follow fewer than five thousand accounts. This function has been
-#'   oriented accordingly (i.e., it assumes the maximum value of n is
-#'   5000). To return more than 5,000 friends for a single user, call
-#'   this function multiple times with requests after the first using
-#'   the `page` parameter.
 #' @seealso <https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids>
 #' @examples
 #'

--- a/R/http.R
+++ b/R/http.R
@@ -61,14 +61,26 @@ TWIT_method <- function(method, token, api,
 
 #' Pagination
 #' 
+#' @description 
+#' `r lifecycle::badge("experimental")`
+#' These are internal functions used for pagination inside of rtweet.
+#' 
 #' @keywords internal
+#' @param token Expert use only. Use this to override authentication for
+#'   a single API call. In most cases you are better off changing the
+#'   default for all calls. See [auth_as()] for details.
 #' @param n Maximum number of results to return.
 #' @param get_id A single argument function that returns a vector of ids given 
 #'   the JSON response. The defaults are chosen to cover the most common cases,
 #'   but you'll need to double check whenever implementing pagination for
 #'   a new endpoint.
-#' @param max_id String giving id of most recent tweet to return. 
-#'   Can be used for manual pagination.
+#' @param max_id Provide an upper bound for the returned results; all results
+#'   will have an ID less than or equal to `max_id`. If omitted, results will 
+#'   start from the most recent available. Supplying `max_id` allows you to 
+#'   manually paginate the results.
+#' @param since_id Provides a lower-bound for the results returned; all results
+#'   will have an ID greater than or equal to `since_id`. This can generally
+#'   be omitted.
 #' @param retryonratelimit If `TRUE`, and a rate limit is exhausted, will wait
 #'   until it refreshes. Most twitter rate limits refresh every 15 minutes.
 #'   If `FALSE`, and the rate limit is exceeded, the function will terminate
@@ -78,6 +90,11 @@ TWIT_method <- function(method, token, api,
 #'   If you expect a query to take hours or days to perform, you should not 
 #'   rely soley on `retryonratelimit` because it does not handle other common
 #'   failure modes like temporarily losing your internet connection.
+#' @param parse The default, `TRUE`, indicates that the result should
+#'   be parsed into a convenient R data structure like a list or data frame. 
+#'   This protects you from the vagaries of the twitter API. Use `FALSE` 
+#'   to return the "raw" list produced by the JSON returned from the twitter 
+#'   API.
 #' @param verbose Show progress bars and other messages indicating current 
 #'   progress?
 TWIT_paginate_max_id <- function(token, api, params, 
@@ -85,11 +102,13 @@ TWIT_paginate_max_id <- function(token, api, params,
                                  n = 1000, 
                                  page_size = 200, 
                                  parse = TRUE,
+                                 since_id = NULL,
                                  max_id = NULL,
                                  count_param = "count", 
                                  retryonratelimit = FALSE,
                                  verbose = TRUE) {
   
+  params$since_id <- since_id
   params[[count_param]] <- page_size  
   pages <- ceiling(n / page_size)
   results <- vector("list", pages)

--- a/R/http.R
+++ b/R/http.R
@@ -69,7 +69,19 @@ TWIT_method <- function(method, token, api,
 #' @param token Expert use only. Use this to override authentication for
 #'   a single API call. In most cases you are better off changing the
 #'   default for all calls. See [auth_as()] for details.
-#' @param n Maximum number of results to return.
+#' @param n Desired number of results to return. Results are downloaded
+#'   in pages when `n` is large; the default value will download a single
+#'   page.
+#'   
+#'   The Twitter API rate limits the number of requests you can perform
+#'   in each 15 minute period. The easiest way to download more than that is 
+#'   to use `retryonratelimit = TRUE`.
+#'   
+#'   You are not guaranteed to get exactly `n` results back. You will get
+#'   fewer results when tweets have been deleted or if you hit a rate limit. 
+#'   You will get more results if you ask for a number of tweets that's not
+#'   a multiple of page size, e.g. if you request `n = 150` and the page
+#'   size is 200, you'll get 200 results back.
 #' @param get_id A single argument function that returns a vector of ids given 
 #'   the JSON response. The defaults are chosen to cover the most common cases,
 #'   but you'll need to double check whenever implementing pagination for

--- a/R/http.R
+++ b/R/http.R
@@ -71,7 +71,7 @@ TWIT_method <- function(method, token, api,
 #'   default for all calls. See [auth_as()] for details.
 #' @param n Desired number of results to return. Results are downloaded
 #'   in pages when `n` is large; the default value will download a single
-#'   page.
+#'   page. Set `n = Inf` to download as many results as possible.
 #'   
 #'   The Twitter API rate limits the number of requests you can perform
 #'   in each 15 minute period. The easiest way to download more than that is 

--- a/R/lists_members.R
+++ b/R/lists_members.R
@@ -1,13 +1,12 @@
 #' Get Twitter list members (users on a given list).
 #'
+#' @inheritParams TWIT_paginate_cursor
 #' @param list_id required The numerical id of the list.
 #' @param slug required You can identify a list by its slug instead of
 #'   its numerical id. If you decide to do so, note that you'll also
 #'   have to specify the list owner using the owner_id or
 #'   owner_user parameters.
 #' @param owner_user optional The screen name or user ID of the user
-#' @inheritParams TWIT_paginate_cursor
-#' @inheritParams lookup_users
 #' @param ... Other arguments used as parameters in query composition.
 #' @return Either a nested list (if parsed) or an HTTP response object.
 #' @examples

--- a/R/lists_memberships.R
+++ b/R/lists_memberships.R
@@ -4,8 +4,8 @@
 #' is often less than the provided n value. This is a reflection of the API and
 #' not a unique quirk of rtweet.
 #' 
-#' @inheritParams get_timeline
 #' @inheritParams TWIT_paginate_cursor
+#' @inheritParams get_timeline
 #' @param filter_to_owned_lists When `TRUE`, will return only lists that
 #'   authenticating user owns.
 #' @param previous_cursor `r lifecycle::badge("deprecated")` Please use 

--- a/R/lists_statuses.R
+++ b/R/lists_statuses.R
@@ -7,7 +7,6 @@
 #'   parameters.
 #' @param owner_user optional The screen name or user ID of the user
 #'   who owns the list being requested by a slug.
-#' @param n optional Specifies the number of results to retrieve per "page."
 #' @param include_rts optional When set to either true, t or 1,
 #'   the list timeline will contain native retweets (if they exist) in
 #'   addition to the standard stream of tweets. The output format of

--- a/R/lists_statuses.R
+++ b/R/lists_statuses.R
@@ -7,20 +7,13 @@
 #'   parameters.
 #' @param owner_user optional The screen name or user ID of the user
 #'   who owns the list being requested by a slug.
-#' @param since_id optional Returns results with an ID greater than
-#'   (that is, more recent than) the specified ID. There are limits to the
-#'   number of Tweets which can be accessed through the API. If the limit
-#'   of Tweets has occurred since the since_id, the since_id will be forced
-#'   to the oldest ID available.
-#' @param max_id optional Returns results with an ID less than (that is,
-#'   older than) or equal to the specified ID.
 #' @param n optional Specifies the number of results to retrieve per "page."
 #' @param include_rts optional When set to either true, t or 1,
 #'   the list timeline will contain native retweets (if they exist) in
 #'   addition to the standard stream of tweets. The output format of
 #'   retweeted tweets is identical to the representation you see in
 #'   home_timeline.
-#' @inheritParams lookup_users
+#' @inheritParams TWIT_paginate_max_id
 #' @family lists
 #' @family tweets
 #' @return data
@@ -42,7 +35,6 @@ lists_statuses <- function(list_id = NULL,
     list_id = list_id,
     slug = slug,
     owner_user = owner_user,
-    since_id = since_id,
     count = n,
     include_rts = include_rts,
     tweet_mode = "extended"
@@ -51,6 +43,7 @@ lists_statuses <- function(list_id = NULL,
   results <- TWIT_paginate_max_id(token, "/1.1/lists/statuses", params,
     page_size = 200,
     max_id = max_id,
+    since_id = since_id,
     n = n,
     parse = parse
   )

--- a/R/lists_subscribers.R
+++ b/R/lists_subscribers.R
@@ -3,8 +3,6 @@
 #' @inheritParams TWIT_paginate_cursor
 #' @param list_id required The numerical id of the list.
 #' @param slug,owner_user The list name (slug) and owner. 
-#' @param n Number of results to return. The default is 20, with a maximum
-#'   of 5,000.
 #' @examples
 #'
 #' \dontrun{

--- a/R/lists_subscribers.R
+++ b/R/lists_subscribers.R
@@ -1,12 +1,10 @@
 #' Get subscribers of a specified list.
 #'
+#' @inheritParams TWIT_paginate_cursor
 #' @param list_id required The numerical id of the list.
 #' @param slug,owner_user The list name (slug) and owner. 
 #' @param n Number of results to return. The default is 20, with a maximum
 #'   of 5,000.
-#' @inheritParams TWIT_paginate_cursor
-#' @inheritParams get_timeline
-#' @inheritParams lookup_users
 #' @examples
 #'
 #' \dontrun{

--- a/R/lists_subscriptions.R
+++ b/R/lists_subscriptions.R
@@ -1,8 +1,7 @@
 #' Get list subscriptions of a given user.
 #'
-#' @inheritParams get_timeline
 #' @inheritParams TWIT_paginate_cursor
-#' @param n Number of lists to return
+#' @inheritParams get_timeline
 #' @examples
 #'
 #' \dontrun{

--- a/R/mentions.R
+++ b/R/mentions.R
@@ -5,19 +5,12 @@
 #' The timeline returned is the equivalent of the one seen when you view 
 #' your mentions on twitter.com.
 #'
+#' @inheritParams TWIT_paginate_max_id
 #' @param n Specifies the number of Tweets to try and retrieve, up to
 #'   a maximum of 200 (the default). The value of count is best
 #'   thought of as a limit to the number of tweets to return because
 #'   suspended or deleted content is removed after the count has been
 #'   applied.
-#' @param since_id Returns results with an ID greater than (that is,
-#'   more recent than) the specified ID. There are limits to the
-#'   number of Tweets which can be accessed through the API. If the
-#'   limit of Tweets has occurred since the since_id, the since_id
-#'   will be forced to the oldest ID available.
-#' @param max_id Character, returns results with an ID less than (that is,
-#'   older than) or equal to `max_id`.
-#' @inheritParams lookup_users
 #' @param ... Other arguments passed as parameters in composed API
 #'   query.
 #' @return Tibble of mentions data.

--- a/R/mentions.R
+++ b/R/mentions.R
@@ -6,11 +6,6 @@
 #' your mentions on twitter.com.
 #'
 #' @inheritParams TWIT_paginate_max_id
-#' @param n Specifies the number of Tweets to try and retrieve, up to
-#'   a maximum of 200 (the default). The value of count is best
-#'   thought of as a limit to the number of tweets to return because
-#'   suspended or deleted content is removed after the count has been
-#'   applied.
 #' @param ... Other arguments passed as parameters in composed API
 #'   query.
 #' @return Tibble of mentions data.

--- a/R/premium.R
+++ b/R/premium.R
@@ -2,11 +2,9 @@
 #'
 #' Search 30day or fullarchive products
 #'
+#' @inheritParams TWIT_paginate_max_id
 #' @param q Search query on which to match/filter tweets. See details for
 #'   information about available search operators.
-#' @param n Number of tweets to return; it is best to set this number in
-#'   intervals of 100 for the '30day' API and either 100 (for sandbox) or 500
-#'   (for paid) for the 'fullarchive' API. Default is 100.
 #' @param fromDate Oldest date-time (YYYYMMDDHHMM) from which tweets should be
 #'   searched for.
 #' @param toDate Newest date-time (YYYYMMDDHHMM) from which tweets should be
@@ -16,7 +14,6 @@
 #'   saved. If the directory doesn't exist, it will be created. If NULL (the
 #'   default) then a dir will be created in the current working directory. To
 #'   override/deactivate safedir set this to FALSE.
-#' @inheritParams lookup_users
 #'
 #' @section Developer Account:
 #' Users must have an approved developer account and an active/labeled

--- a/R/search_tweets.R
+++ b/R/search_tweets.R
@@ -3,7 +3,6 @@
 #' Returns Twitter statuses matching a user provided search
 #' query. ONLY RETURNS DATA FROM THE PAST 6-9 DAYS. 
 #'
-#' @inheritParams lookup_users
 #' @param q Query to be searched, used to filter and select tweets to
 #'   return from Twitter's REST API. Must be a character string not to
 #'   exceed maximum of 500 characters. Spaces behave like boolean

--- a/R/search_tweets.R
+++ b/R/search_tweets.R
@@ -34,17 +34,6 @@
 #' }
 #'
 #' @inheritParams TWIT_paginate_max_id
-#' @param n Integer giving the total number of tweets to download.
-#' 
-#'   Results are downloaded in pages of 100, and you can download 180 pages
-#'   (e.g. 18,000 tweets) in each 15 minute period. The easiest way to download 
-#'   more than that is to use `retryonratelimit = TRUE`.
-#'   
-#'   You are not guaranteed to get exactly `n` results back. You will get
-#'   fewer results when tweets have been deleted or if you hit a rate limit. 
-#'   You will get more results if you ask for a number of tweets that's not
-#'   a multiple of page size, e.g. if you request `n = 150` you'll get 200 
-#'   tweets back.
 #' @param type Character string specifying which type of search
 #'   results to return from Twitter's REST API. The current default is
 #'   `type = "recent"`, other valid types include `type =

--- a/R/timeline.R
+++ b/R/timeline.R
@@ -7,10 +7,6 @@
 #' @inheritParams TWIT_paginate_max_id
 #' @param user Character vector of screen names or user ids. 
 #'   See [as_screenname()] for more details.
-#' @param n Number of tweets to return per timeline. Defaults to 100.
-#'   Must be of length 1 or equal to length of user. This number should
-#'   not exceed 3200 as Twitter limits returns to the most recent 3,200
-#'   statuses posted or retweeted by each user.
 #' @param home Logical, indicating whether to return a "user" timeline
 #'   (the default, what a user has tweeted/retweeted) or a "home" timeline 
 #'   (what the user would see if they logged into twitter). 

--- a/R/timeline.R
+++ b/R/timeline.R
@@ -4,15 +4,13 @@
 #' have tweeted). `get_my_timeline()` returns the home timeline for the 
 #' authenticated user (i.e. the tweets you see when you log into Twitter).
 #'
-#' @inheritParams lookup_users
+#' @inheritParams TWIT_paginate_max_id
 #' @param user Character vector of screen names or user ids. 
 #'   See [as_screenname()] for more details.
 #' @param n Number of tweets to return per timeline. Defaults to 100.
 #'   Must be of length 1 or equal to length of user. This number should
 #'   not exceed 3200 as Twitter limits returns to the most recent 3,200
 #'   statuses posted or retweeted by each user.
-#' @param max_id Character, returns results with an ID less than (that is,
-#'   older than) or equal to `max_id`.
 #' @param home Logical, indicating whether to return a "user" timeline
 #'   (the default, what a user has tweeted/retweeted) or a "home" timeline 
 #'   (what the user would see if they logged into twitter). 

--- a/R/users.R
+++ b/R/users.R
@@ -1,14 +1,6 @@
 #' Get Twitter users data for given users (user IDs or screen names).
 #'
 #' @inheritParams TWIT_paginate_max_id
-#' @param token Expert use only. Use this to override authentication for
-#'   a single API call. In most cases you are better off changing the
-#'   default for all calls. See [auth_as()] for details.
-#' @param parse The default, `TRUE`, indicates that the result should
-#'   be parsed into a convenient R data structure like a list or data frame. 
-#'   This protects you from the vagaries of the twitter API. Use `FALSE` 
-#'   to return the "raw" list produced by the JSON returned from the twitter 
-#'   API.
 #'   
 #' @param users User id or screen name of target user.
 #' @seealso <https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-lookup>

--- a/man/TWIT_paginate_max_id.Rd
+++ b/man/TWIT_paginate_max_id.Rd
@@ -51,7 +51,19 @@ the JSON response. The defaults are chosen to cover the most common cases,
 but you'll need to double check whenever implementing pagination for
 a new endpoint.}
 
-\item{n}{Maximum number of results to return.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{parse}{The default, \code{TRUE}, indicates that the result should
 be parsed into a convenient R data structure like a list or data frame.

--- a/man/TWIT_paginate_max_id.Rd
+++ b/man/TWIT_paginate_max_id.Rd
@@ -53,7 +53,7 @@ a new endpoint.}
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/TWIT_paginate_max_id.Rd
+++ b/man/TWIT_paginate_max_id.Rd
@@ -14,6 +14,7 @@ TWIT_paginate_max_id(
   n = 1000,
   page_size = 200,
   parse = TRUE,
+  since_id = NULL,
   max_id = NULL,
   count_param = "count",
   retryonratelimit = FALSE,
@@ -41,6 +42,10 @@ TWIT_paginate_chunked(
 )
 }
 \arguments{
+\item{token}{Expert use only. Use this to override authentication for
+a single API call. In most cases you are better off changing the
+default for all calls. See \code{\link[=auth_as]{auth_as()}} for details.}
+
 \item{get_id}{A single argument function that returns a vector of ids given
 the JSON response. The defaults are chosen to cover the most common cases,
 but you'll need to double check whenever implementing pagination for
@@ -48,8 +53,20 @@ a new endpoint.}
 
 \item{n}{Maximum number of results to return.}
 
-\item{max_id}{String giving id of most recent tweet to return.
-Can be used for manual pagination.}
+\item{parse}{The default, \code{TRUE}, indicates that the result should
+be parsed into a convenient R data structure like a list or data frame.
+This protects you from the vagaries of the twitter API. Use \code{FALSE}
+to return the "raw" list produced by the JSON returned from the twitter
+API.}
+
+\item{since_id}{Provides a lower-bound for the results returned; all results
+will have an ID greater than or equal to \code{since_id}. This can generally
+be omitted.}
+
+\item{max_id}{Provide an upper bound for the returned results; all results
+will have an ID less than or equal to \code{max_id}. If omitted, results will
+start from the most recent available. Supplying \code{max_id} allows you to
+manually paginate the results.}
 
 \item{retryonratelimit}{If \code{TRUE}, and a rate limit is exhausted, will wait
 until it refreshes. Most twitter rate limits refresh every 15 minutes.
@@ -68,6 +85,7 @@ progress?}
 the first page; can be used for manual pagination.}
 }
 \description{
-Pagination
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+These are internal functions used for pagination inside of rtweet.
 }
 \keyword{internal}

--- a/man/direct_messages.Rd
+++ b/man/direct_messages.Rd
@@ -16,7 +16,7 @@ direct_messages(
 \arguments{
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/direct_messages.Rd
+++ b/man/direct_messages.Rd
@@ -14,7 +14,19 @@ direct_messages(
 )
 }
 \arguments{
-\item{n}{Maximum number of results to return.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{cursor}{Which page of results to return. The default will return
 the first page; can be used for manual pagination.}

--- a/man/direct_messages.Rd
+++ b/man/direct_messages.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/direct_messages.R
 \name{direct_messages}
 \alias{direct_messages}
-\alias{direct_messages_sent}
 \title{Get direct messages sent to and received by the authenticating user from the
 past 30 days}
 \usage{
@@ -10,14 +9,6 @@ direct_messages(
   n = 50,
   cursor = NULL,
   next_cursor = NULL,
-  parse = TRUE,
-  token = NULL
-)
-
-direct_messages_sent(
-  since_id = NULL,
-  max_id = NULL,
-  n = 200,
   parse = TRUE,
   token = NULL
 )
@@ -39,15 +30,6 @@ API.}
 \item{token}{Expert use only. Use this to override authentication for
 a single API call. In most cases you are better off changing the
 default for all calls. See \code{\link[=auth_as]{auth_as()}} for details.}
-
-\item{since_id}{optional Returns results with an ID greater than
-(that is, more recent than) the specified ID. There are limits to
-the number of Tweets which can be accessed through the API. If
-the limit of Tweets has occurred since the since_id, the since_id
-will be forced to the oldest ID available.}
-
-\item{max_id}{String giving id of most recent tweet to return.
-Can be used for manual pagination.}
 }
 \value{
 A list with one element for each page of results.

--- a/man/direct_messages_received.Rd
+++ b/man/direct_messages_received.Rd
@@ -21,13 +21,6 @@ direct_messages_sent(
   token = NULL
 )
 }
-\arguments{
-\item{n}{optional Specifies the number of direct messages to try
-and retrieve, up to a maximum of 200. The value of count is best
-thought of as a limit to the number of Tweets to return because
-suspended or deleted content is removed after the count has been
-applied.}
-}
 \value{
 Return object converted to nested list. If status code of
 response object is not 200, the response object is returned

--- a/man/direct_messages_received.Rd
+++ b/man/direct_messages_received.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/direct_messages.R
 \name{direct_messages_received}
 \alias{direct_messages_received}
+\alias{direct_messages_sent}
 \title{(DEPRECATED) Get the most recent direct messages sent to the authenticating user.}
 \usage{
 direct_messages_received(
@@ -11,32 +12,21 @@ direct_messages_received(
   parse = TRUE,
   token = NULL
 )
+
+direct_messages_sent(
+  since_id = NULL,
+  max_id = NULL,
+  n = 200,
+  parse = TRUE,
+  token = NULL
+)
 }
 \arguments{
-\item{since_id}{optional Returns results with an ID greater than
-(that is, more recent than) the specified ID. There are limits to
-the number of Tweets which can be accessed through the API. If
-the limit of Tweets has occurred since the since_id, the since_id
-will be forced to the oldest ID available.}
-
-\item{max_id}{Character, returns results with an ID less than (that is,
-older than) or equal to \code{max_id}.}
-
 \item{n}{optional Specifies the number of direct messages to try
 and retrieve, up to a maximum of 200. The value of count is best
 thought of as a limit to the number of Tweets to return because
 suspended or deleted content is removed after the count has been
 applied.}
-
-\item{parse}{The default, \code{TRUE}, indicates that the result should
-be parsed into a convenient R data structure like a list or data frame.
-This protects you from the vagaries of the twitter API. Use \code{FALSE}
-to return the "raw" list produced by the JSON returned from the twitter
-API.}
-
-\item{token}{Expert use only. Use this to override authentication for
-a single API call. In most cases you are better off changing the
-default for all calls. See \code{\link[=auth_as]{auth_as()}} for details.}
 }
 \value{
 Return object converted to nested list. If status code of

--- a/man/get_favorites.Rd
+++ b/man/get_favorites.Rd
@@ -24,9 +24,14 @@ request. Higher numbers will require multiple requests.
 \code{n} is applied before removing any tweets that have been suspended or
 deleted.}
 
-\item{since_id, max_id}{Limit tweets to ids in \verb{(since_id, max_id]}.
-If \code{since_id} is smaller than the earliest tweet available to the API,
-it will be forced to the oldest tweet available.}
+\item{since_id}{Provides a lower-bound for the results returned; all results
+will have an ID greater than or equal to \code{since_id}. This can generally
+be omitted.}
+
+\item{max_id}{Provide an upper bound for the returned results; all results
+will have an ID less than or equal to \code{max_id}. If omitted, results will
+start from the most recent available. Supplying \code{max_id} allows you to
+manually paginate the results.}
 
 \item{parse}{The default, \code{TRUE}, indicates that the result should
 be parsed into a convenient R data structure like a list or data frame.

--- a/man/get_favorites.Rd
+++ b/man/get_favorites.Rd
@@ -17,12 +17,19 @@ get_favorites(
 \item{user}{Character vector of screen names or user ids.
 See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
-\item{n}{Specifies the number of records to retrieve. Defaults to 200,
-which is the maximum number of records that can be retrieved in a single
-request. Higher numbers will require multiple requests.
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
 
-\code{n} is applied before removing any tweets that have been suspended or
-deleted.}
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{since_id}{Provides a lower-bound for the results returned; all results
 will have an ID greater than or equal to \code{since_id}. This can generally

--- a/man/get_favorites.Rd
+++ b/man/get_favorites.Rd
@@ -19,7 +19,7 @@ See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/get_followers.Rd
+++ b/man/get_followers.Rd
@@ -19,11 +19,19 @@ get_followers(
 \item{user}{Character vector of screen names or user ids.
 See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
-\item{n}{Number of followers to return. Use \code{Inf} to download all followers.
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page. Set \code{n = Inf} to download as many results as possible.
 
-Results are downloaded in pages of 5000, and you can download 15 pages
-(i.e. 75,000 tweets) in each 15 minute period. The easiest way to download
-more than that is to set \code{retryonratelimit = TRUE}.}
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{cursor}{Which page of results to return. The default will return
 the first page; can be used for manual pagination.}

--- a/man/get_friends.Rd
+++ b/man/get_friends.Rd
@@ -20,18 +20,19 @@ get_friends(
 user IDs of friends (accounts followed BY target user) will be
 retrieved.}
 
-\item{n}{Number of friends (user IDs) to return. Defaults to 5,000,
-which is the maximum returned by a single API call. Users are
-limited to 15 of these requests per 15 minutes. Twitter limits
-the number of friends a user can have to 5,000. To follow more
-than 5,000 accounts (to have more than 5 thousand "friends")
-accounts must meet certain requirements (e.g., a certain ratio of
-followers to friends). Consequently, the vast majority of users
-follow fewer than five thousand accounts. This function has been
-oriented accordingly (i.e., it assumes the maximum value of n is
-5000). To return more than 5,000 friends for a single user, call
-this function multiple times with requests after the first using
-the \code{page} parameter.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page. Set \code{n = Inf} to download as many results as possible.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{retryonratelimit}{If \code{TRUE}, and a rate limit is exhausted, will wait
 until it refreshes. Most twitter rate limits refresh every 15 minutes.
@@ -68,6 +69,11 @@ user and "user_id" for follower IDs.
 \description{
 Returns a list of user IDs for the accounts following BY one or
 more specified users.
+}
+\details{
+Generally, you should not need to set \code{n} to more than 5,000 since Twitter
+limits the number of people that you can follow (i.e. to follow more than
+5,000 people at least 5,000 people need to follow you).
 }
 \examples{
 

--- a/man/get_mentions.Rd
+++ b/man/get_mentions.Rd
@@ -16,7 +16,7 @@ get_mentions(
 \arguments{
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/get_mentions.Rd
+++ b/man/get_mentions.Rd
@@ -20,14 +20,14 @@ thought of as a limit to the number of tweets to return because
 suspended or deleted content is removed after the count has been
 applied.}
 
-\item{since_id}{Returns results with an ID greater than (that is,
-more recent than) the specified ID. There are limits to the
-number of Tweets which can be accessed through the API. If the
-limit of Tweets has occurred since the since_id, the since_id
-will be forced to the oldest ID available.}
+\item{since_id}{Provides a lower-bound for the results returned; all results
+will have an ID greater than or equal to \code{since_id}. This can generally
+be omitted.}
 
-\item{max_id}{Character, returns results with an ID less than (that is,
-older than) or equal to \code{max_id}.}
+\item{max_id}{Provide an upper bound for the returned results; all results
+will have an ID less than or equal to \code{max_id}. If omitted, results will
+start from the most recent available. Supplying \code{max_id} allows you to
+manually paginate the results.}
 
 \item{parse}{The default, \code{TRUE}, indicates that the result should
 be parsed into a convenient R data structure like a list or data frame.

--- a/man/get_mentions.Rd
+++ b/man/get_mentions.Rd
@@ -14,11 +14,19 @@ get_mentions(
 )
 }
 \arguments{
-\item{n}{Specifies the number of Tweets to try and retrieve, up to
-a maximum of 200 (the default). The value of count is best
-thought of as a limit to the number of tweets to return because
-suspended or deleted content is removed after the count has been
-applied.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{since_id}{Provides a lower-bound for the results returned; all results
 will have an ID greater than or equal to \code{since_id}. This can generally

--- a/man/get_timeline.Rd
+++ b/man/get_timeline.Rd
@@ -30,10 +30,19 @@ get_my_timeline(
 \item{user}{Character vector of screen names or user ids.
 See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
-\item{n}{Number of tweets to return per timeline. Defaults to 100.
-Must be of length 1 or equal to length of user. This number should
-not exceed 3200 as Twitter limits returns to the most recent 3,200
-statuses posted or retweeted by each user.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{max_id}{Provide an upper bound for the returned results; all results
 will have an ID less than or equal to \code{max_id}. If omitted, results will

--- a/man/get_timeline.Rd
+++ b/man/get_timeline.Rd
@@ -35,8 +35,10 @@ Must be of length 1 or equal to length of user. This number should
 not exceed 3200 as Twitter limits returns to the most recent 3,200
 statuses posted or retweeted by each user.}
 
-\item{max_id}{Character, returns results with an ID less than (that is,
-older than) or equal to \code{max_id}.}
+\item{max_id}{Provide an upper bound for the returned results; all results
+will have an ID less than or equal to \code{max_id}. If omitted, results will
+start from the most recent available. Supplying \code{max_id} allows you to
+manually paginate the results.}
 
 \item{home}{Logical, indicating whether to return a "user" timeline
 (the default, what a user has tweeted/retweeted) or a "home" timeline

--- a/man/get_timeline.Rd
+++ b/man/get_timeline.Rd
@@ -32,7 +32,7 @@ See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/lists_members.Rd
+++ b/man/lists_members.Rd
@@ -27,7 +27,7 @@ owner_user parameters.}
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/lists_members.Rd
+++ b/man/lists_members.Rd
@@ -25,7 +25,19 @@ owner_user parameters.}
 
 \item{owner_user}{optional The screen name or user ID of the user}
 
-\item{n}{Maximum number of results to return.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{cursor}{Which page of results to return. The default will return
 the first page; can be used for manual pagination.}

--- a/man/lists_memberships.Rd
+++ b/man/lists_memberships.Rd
@@ -20,7 +20,7 @@ See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/lists_memberships.Rd
+++ b/man/lists_memberships.Rd
@@ -18,7 +18,19 @@ lists_memberships(
 \item{user}{Character vector of screen names or user ids.
 See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
-\item{n}{Maximum number of results to return.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{cursor}{Which page of results to return. The default will return
 the first page; can be used for manual pagination.}

--- a/man/lists_memberships.Rd
+++ b/man/lists_memberships.Rd
@@ -18,10 +18,7 @@ lists_memberships(
 \item{user}{Character vector of screen names or user ids.
 See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
-\item{n}{Number of tweets to return per timeline. Defaults to 100.
-Must be of length 1 or equal to length of user. This number should
-not exceed 3200 as Twitter limits returns to the most recent 3,200
-statuses posted or retweeted by each user.}
+\item{n}{Maximum number of results to return.}
 
 \item{cursor}{Which page of results to return. The default will return
 the first page; can be used for manual pagination.}

--- a/man/lists_statuses.Rd
+++ b/man/lists_statuses.Rd
@@ -36,7 +36,19 @@ will have an ID less than or equal to \code{max_id}. If omitted, results will
 start from the most recent available. Supplying \code{max_id} allows you to
 manually paginate the results.}
 
-\item{n}{optional Specifies the number of results to retrieve per "page."}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{include_rts}{optional When set to either true, t or 1,
 the list timeline will contain native retweets (if they exist) in

--- a/man/lists_statuses.Rd
+++ b/man/lists_statuses.Rd
@@ -38,7 +38,7 @@ manually paginate the results.}
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/lists_statuses.Rd
+++ b/man/lists_statuses.Rd
@@ -27,14 +27,14 @@ parameters.}
 \item{owner_user}{optional The screen name or user ID of the user
 who owns the list being requested by a slug.}
 
-\item{since_id}{optional Returns results with an ID greater than
-(that is, more recent than) the specified ID. There are limits to the
-number of Tweets which can be accessed through the API. If the limit
-of Tweets has occurred since the since_id, the since_id will be forced
-to the oldest ID available.}
+\item{since_id}{Provides a lower-bound for the results returned; all results
+will have an ID greater than or equal to \code{since_id}. This can generally
+be omitted.}
 
-\item{max_id}{optional Returns results with an ID less than (that is,
-older than) or equal to the specified ID.}
+\item{max_id}{Provide an upper bound for the returned results; all results
+will have an ID less than or equal to \code{max_id}. If omitted, results will
+start from the most recent available. Supplying \code{max_id} allows you to
+manually paginate the results.}
 
 \item{n}{optional Specifies the number of results to retrieve per "page."}
 

--- a/man/lists_subscribers.Rd
+++ b/man/lists_subscribers.Rd
@@ -21,7 +21,7 @@ lists_subscribers(
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/lists_subscribers.Rd
+++ b/man/lists_subscribers.Rd
@@ -19,8 +19,19 @@ lists_subscribers(
 
 \item{slug, owner_user}{The list name (slug) and owner.}
 
-\item{n}{Number of results to return. The default is 20, with a maximum
-of 5,000.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{cursor}{Which page of results to return. The default will return
 the first page; can be used for manual pagination.}

--- a/man/lists_subscriptions.Rd
+++ b/man/lists_subscriptions.Rd
@@ -12,7 +12,7 @@ See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/lists_subscriptions.Rd
+++ b/man/lists_subscriptions.Rd
@@ -10,7 +10,19 @@ lists_subscriptions(user, n = 20, cursor = "-1", parse = TRUE, token = NULL)
 \item{user}{Character vector of screen names or user ids.
 See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
-\item{n}{Maximum number of results to return.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{cursor}{Which page of results to return. The default will return
 the first page; can be used for manual pagination.}

--- a/man/lists_subscriptions.Rd
+++ b/man/lists_subscriptions.Rd
@@ -10,7 +10,7 @@ lists_subscriptions(user, n = 20, cursor = "-1", parse = TRUE, token = NULL)
 \item{user}{Character vector of screen names or user ids.
 See \code{\link[=as_screenname]{as_screenname()}} for more details.}
 
-\item{n}{Number of lists to return}
+\item{n}{Maximum number of results to return.}
 
 \item{cursor}{Which page of results to return. The default will return
 the first page; can be used for manual pagination.}

--- a/man/search_fullarchive.Rd
+++ b/man/search_fullarchive.Rd
@@ -31,9 +31,19 @@ search_30day(
 \item{q}{Search query on which to match/filter tweets. See details for
 information about available search operators.}
 
-\item{n}{Number of tweets to return; it is best to set this number in
-intervals of 100 for the '30day' API and either 100 (for sandbox) or 500
-(for paid) for the 'fullarchive' API. Default is 100.}
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
+
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
+
+You are not guaranteed to get exactly \code{n} results back. You will get
+fewer results when tweets have been deleted or if you hit a rate limit.
+You will get more results if you ask for a number of tweets that's not
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{fromDate}{Oldest date-time (YYYYMMDDHHMM) from which tweets should be
 searched for.}

--- a/man/search_fullarchive.Rd
+++ b/man/search_fullarchive.Rd
@@ -33,7 +33,7 @@ information about available search operators.}
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/search_tweets.Rd
+++ b/man/search_tweets.Rd
@@ -75,8 +75,10 @@ entering "RT" into the text of one's tweets).}
 \item{geocode}{Geographical limiter of the template
 "latitude,longitude,radius" e.g., \code{geocode = "37.78,-122.40,1mi"}.}
 
-\item{max_id}{String giving id of most recent tweet to return.
-Can be used for manual pagination.}
+\item{max_id}{Provide an upper bound for the returned results; all results
+will have an ID less than or equal to \code{max_id}. If omitted, results will
+start from the most recent available. Supplying \code{max_id} allows you to
+manually paginate the results.}
 
 \item{parse}{The default, \code{TRUE}, indicates that the result should
 be parsed into a convenient R data structure like a list or data frame.

--- a/man/search_tweets.Rd
+++ b/man/search_tweets.Rd
@@ -51,7 +51,7 @@ Some other useful query tips:
 
 \item{n}{Desired number of results to return. Results are downloaded
 in pages when \code{n} is large; the default value will download a single
-page.
+page. Set \code{n = Inf} to download as many results as possible.
 
 The Twitter API rate limits the number of requests you can perform
 in each 15 minute period. The easiest way to download more than that is

--- a/man/search_tweets.Rd
+++ b/man/search_tweets.Rd
@@ -49,17 +49,19 @@ Some other useful query tips:
 \item Filter (return only) tweets with media \code{"filter:media"}
 }}
 
-\item{n}{Integer giving the total number of tweets to download.
+\item{n}{Desired number of results to return. Results are downloaded
+in pages when \code{n} is large; the default value will download a single
+page.
 
-Results are downloaded in pages of 100, and you can download 180 pages
-(e.g. 18,000 tweets) in each 15 minute period. The easiest way to download
-more than that is to use \code{retryonratelimit = TRUE}.
+The Twitter API rate limits the number of requests you can perform
+in each 15 minute period. The easiest way to download more than that is
+to use \code{retryonratelimit = TRUE}.
 
 You are not guaranteed to get exactly \code{n} results back. You will get
 fewer results when tweets have been deleted or if you hit a rate limit.
 You will get more results if you ask for a number of tweets that's not
-a multiple of page size, e.g. if you request \code{n = 150} you'll get 200
-tweets back.}
+a multiple of page size, e.g. if you request \code{n = 150} and the page
+size is 200, you'll get 200 results back.}
 
 \item{type}{Character string specifying which type of search
 results to return from Twitter's REST API. The current default is


### PR DESCRIPTION
I've tried to document all parameters related to pagination in one place: the documentation for `TWIT_paginate_max_id`/`TWIT_paginate_cursor`. This means that the docs lose less specific details about the endpoint (e.g. specific page sizes and rate limits) but gain more general details about how all the pieces fit together.

@llrs I think the best place to focus on is the `TWIT_paginate_max_id` documentation, since that now flows out to the majority of functions in rtweet. Let me know if there's anything you think is confusing so that I can improve the wording as much as possible.