### PR TITLE
return parameters from my_list_params

### DIFF
--- a/R/post-list.R
+++ b/R/post-list.R
@@ -217,5 +217,5 @@ my_list_params <- function(token, slug = NULL, list_id = NULL, ..., users = NULL
   if (!is.null(users)) {
     params[[user_type(users, "users")]] <- paste0(users, collapse = ",")
   }
-  
+  params
 }


### PR DESCRIPTION
`my_list_params()` was not returning the parameters object properly to pass on to the `post_list*` functions.  This fixes that.