### PR TITLE
Add gitPod R Dockerfile and yml file

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,3 @@
+FROM gitpod/workspace-full
+
+RUN brew install R

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
+vscode:
+  extensions:
+    - Ikuyadeu.r@1.2.1:z5vr1v1bfS++U/aHLSXQ6Q==


### PR DESCRIPTION
Followed the instructions at: https://www.gitpod.io/docs/languages/r/

The idea is someone should be able to go to https://gitpod.io/#https://github.com/ropensci/rtweet and get an instant cloud dev environment.

This commit creates an R environment with the rtweet repo loaded, but I am not familiar with all of the necessary dependencies in rtweet and it was not building ("R" command line REPL is running correctly and the files were downloading fine, but I was getting gcc5 and other errors when trying to install rtweet).

I thought I'd share this incremental work in case someone understands the dependencies better and can make it full working.