### PR TITLE
Allowing n=Inf in get_favorites (or elsewhere)

### DIFF
--- a/R/favorites.R
+++ b/R/favorites.R
@@ -50,7 +50,7 @@ get_favorites_user <- function(user, ..., parse = TRUE, token = NULL) {
     include_ext_alt_text = "true"
   )
   params[[user_type(user)]] <- user
-
+  
   results <- TWIT_paginate_max_id(token, "/1.1/favorites/list", params,
     page_size = 200,
     ...

--- a/R/favorites.R
+++ b/R/favorites.R
@@ -50,7 +50,7 @@ get_favorites_user <- function(user, ..., parse = TRUE, token = NULL) {
     include_ext_alt_text = "true"
   )
   params[[user_type(user)]] <- user
-  
+
   results <- TWIT_paginate_max_id(token, "/1.1/favorites/list", params,
     page_size = 200,
     ...

--- a/R/http.R
+++ b/R/http.R
@@ -121,10 +121,7 @@ TWIT_paginate_max_id <- function(token, api, params,
   params$since_id <- since_id
   params[[count_param]] <- page_size  
   pages <- ceiling(n / page_size)
-  if (is.finite(pages)) {
-    results <- vector("list", pages)
-  } else {
-    results <- vector("list", 1000) #see https://github.com/ropensci/rtweet/pull/567#issuecomment-821169712
+results <- vector("list", if (is.finite(pages)) pages else 1000)
   }
   
   if (verbose)  {

--- a/R/http.R
+++ b/R/http.R
@@ -121,12 +121,7 @@ TWIT_paginate_max_id <- function(token, api, params,
   params$since_id <- since_id
   params[[count_param]] <- page_size  
   pages <- ceiling(n / page_size)
-  
-  if (is.finite(n)) {
-    results <- vector("list", pages)
-  } else {
-    results <- vector("list", 2)
-  }
+  results <- vector("list", pages)
   
   if (verbose)  {
     pb <- progress::progress_bar$new(
@@ -135,10 +130,8 @@ TWIT_paginate_max_id <- function(token, api, params,
     ) 
     withr::defer(pb$terminate())
   }
-  
-  #because pages (because of n=Inf) might be ex ante infinite we can't use a for loop.
-  i <- 0 
-  while(i<-i+1 <=pages) {
+
+  for (i in seq_len(pages)) {
     params$max_id <- max_id
     if (i == pages) {
       params[[count_param]] <- n - (pages - 1) * page_size
@@ -165,22 +158,15 @@ TWIT_paginate_max_id <- function(token, api, params,
       break
     }
     
-    #dynamically resize results, if n was inf. Based on https://github.com/ropensci/rtweet/pull/567#issuecomment-821169712
-    if (length(results)<i & is.infinite(n)) {
-      cat("resizing")
-      length(results)<-length(results)*2
-    }
-    
     max_id <- max_id(id)
     results[[i]] <- json
     
     if (verbose) {
       pb$tick()
     }
-    
   }
 
-  results[1:i]
+  results
 }
 
 # https://developer.twitter.com/en/docs/pagination

--- a/R/http.R
+++ b/R/http.R
@@ -121,8 +121,7 @@ TWIT_paginate_max_id <- function(token, api, params,
   params$since_id <- since_id
   params[[count_param]] <- page_size  
   pages <- ceiling(n / page_size)
-results <- vector("list", if (is.finite(pages)) pages else 1000)
-  }
+  results <- vector("list", if (is.finite(pages)) pages else 1000)
   
   if (verbose)  {
     pb <- progress::progress_bar$new(
@@ -132,8 +131,9 @@ results <- vector("list", if (is.finite(pages)) pages else 1000)
     withr::defer(pb$terminate())
   }
   
-  i<-0
-  while ((i<-i+1) <= pages) {
+  i <- 0
+  while (i < pages) {
+    i <- i+1
     params$max_id <- max_id
     if (i == pages) {
       params[[count_param]] <- n - (pages - 1) * page_size
@@ -159,8 +159,8 @@ results <- vector("list", if (is.finite(pages)) pages else 1000)
     if (length(id) == 0) {
       break
     }
-    if(i>length(results)) { #doubling size, based on https://github.com/ropensci/rtweet/pull/567#issuecomment-821169712
-      length(results)<-2*length(results)
+    if(i>length(results)) { #doubling size, see https://en.wikipedia.org/wiki/Dynamic_array#Geometric_expansion_and_amortized_cost
+      length(results) <- 2 * length(results)
     }
     
     max_id <- max_id(id)
@@ -170,7 +170,7 @@ results <- vector("list", if (is.finite(pages)) pages else 1000)
       pb$tick()
     }
   }
-  results[1:i]
+  results
 }
 
 # https://developer.twitter.com/en/docs/pagination

--- a/R/http.R
+++ b/R/http.R
@@ -159,7 +159,8 @@ TWIT_paginate_max_id <- function(token, api, params,
     if (length(id) == 0) {
       break
     }
-    if(i>length(results)) { #doubling size, see https://en.wikipedia.org/wiki/Dynamic_array#Geometric_expansion_and_amortized_cost
+    if(i > length(results)) { 
+      # double length per https://en.wikipedia.org/wiki/Dynamic_array#Geometric_expansion_and_amortized_cost
       length(results) <- 2 * length(results)
     }
     

--- a/R/http.R
+++ b/R/http.R
@@ -136,7 +136,7 @@ TWIT_paginate_max_id <- function(token, api, params,
   }
   
   i<-0
-  while ((i<-i+1) < pages) {
+  while ((i<-i+1) <= pages) {
     params$max_id <- max_id
     if (i == pages) {
       params[[count_param]] <- n - (pages - 1) * page_size

--- a/R/http.R
+++ b/R/http.R
@@ -121,7 +121,12 @@ TWIT_paginate_max_id <- function(token, api, params,
   params$since_id <- since_id
   params[[count_param]] <- page_size  
   pages <- ceiling(n / page_size)
-  results <- vector("list", pages)
+  
+  if (is.finite(n)) {
+    results <- vector("list", pages)
+  } else {
+    results <- vector("list", 2)
+  }
   
   if (verbose)  {
     pb <- progress::progress_bar$new(
@@ -130,8 +135,10 @@ TWIT_paginate_max_id <- function(token, api, params,
     ) 
     withr::defer(pb$terminate())
   }
-
-  for (i in seq_len(pages)) {
+  
+  #because pages (because of n=Inf) might be ex ante infinite we can't use a for loop.
+  i <- 0 
+  while(i<-i+1 <=pages) {
     params$max_id <- max_id
     if (i == pages) {
       params[[count_param]] <- n - (pages - 1) * page_size
@@ -158,15 +165,22 @@ TWIT_paginate_max_id <- function(token, api, params,
       break
     }
     
+    #dynamically resize results, if n was inf. Based on https://github.com/ropensci/rtweet/pull/567#issuecomment-821169712
+    if (length(results)<i & is.infinite(n)) {
+      cat("resizing")
+      length(results)<-length(results)*2
+    }
+    
     max_id <- max_id(id)
     results[[i]] <- json
     
     if (verbose) {
       pb$tick()
     }
+    
   }
 
-  results
+  results[1:i]
 }
 
 # https://developer.twitter.com/en/docs/pagination

--- a/tests/testthat/test-friends.R
+++ b/tests/testthat/test-friends.R
@@ -33,3 +33,8 @@ test_that("my_friendships works", {
   mf <- my_friendships("hadley")
   expect_s3_class(mf, "data.frame")
 })
+
+test_that("n = Inf works", {
+  mf <- get_friends("SmallBuStudio", n = Inf)
+  expect_s3_class(mf, "data.frame")
+})


### PR DESCRIPTION
This is attempt to address https://github.com/ropensci/rtweet/issues/566.

The for-loop over pages is replaced by a while loop with a in-line counter. If `n` is finite the routine should be unchanged compared to the previous version. If `n` is finite, the result list is initiated to 1000 elements and doubled every time the boundary is hit (see: https://github.com/ropensci/rtweet/pull/567#issuecomment-821169712).

I followed @hadley's suggestion here, but I am not sure I understand why we cannot dynamically grow the return vector. The memory burden seems negligible to me, but I am clearly no expert here.
