### PR TITLE
Fix parsing failure in lookup_users(). Fixes #597

### DIFF
--- a/R/tweets_and_users.R
+++ b/R/tweets_and_users.R
@@ -26,8 +26,11 @@ users_with_tweets <- function(x) {
   tweets_raw <- lapply(x, function(x) x[["status"]])
   tweets_tbl <- lapply(tweets_raw, tweets_to_tbl_)
   tweets <- do.call("rbind", tweets_tbl)
-  tweets$user_id <- users$user_id
-  tweets$screen_name <- users$screen_name
+  
+  if (NROW(tweets) > 0) {
+    tweets$user_id <- users$user_id
+    tweets$screen_name <- users$screen_name
+  }
   
   structure(users, tweets = tweets)
 }


### PR DESCRIPTION
After fix. See #597 for comparison. Not going to write a test since finding a user with no tweets that will never have any tweets seems unlikely.

``` r
library(rtweet)

user_stuff <- lookup_users("ConvertedBook")
user_stuff
#> # A tibble: 1 x 20
#>   user_id name  screen_name location description url   protected followers_count
#> * <chr>   <chr> <chr>       <chr>    <chr>       <lgl> <lgl>               <int>
#> 1 140779… Neil… ConvertedB… ""       ""          NA    FALSE                   2
#> # … with 12 more variables: friends_count <int>, listed_count <int>,
#> #   statuses_count <int>, favourites_count <int>, account_created_at <dttm>,
#> #   verified <lgl>, profile_url <chr>, profile_expanded_url <chr>,
#> #   account_lang <lgl>, profile_banner_url <lgl>, profile_background_url <lgl>,
#> #   profile_image_url <chr>

tweets_data(user_stuff)
#> data frame with 0 columns and 0 rows
```

<sup>Created on 2021-07-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>