### PR TITLE
Adjust naming convention for follower and friend columns 

### DIFF
--- a/R/followers.R
+++ b/R/followers.R
@@ -17,8 +17,8 @@
 #' more_users <- get_followers("KFC", cursor = users)
 #'
 #' }
-#' @return A tibble data frame with one column named "from_id" with the 
-#' followers and another one "to_id" with the user used as input.
+#' @return A tibble data frame with one column named "follower_of" with the 
+#' followers and another one "user_id" with the user used as input.
 #' @export
 get_followers <- function(user, n = 5000,
                           cursor = "-1",
@@ -47,8 +47,8 @@ get_followers <- function(user, n = 5000,
   )
   
   if (parse) {
-    df <- tibble::tibble(from_id = unlist(lapply(results, function(x) x$ids)),
-                         to_id = user)
+    df <- tibble::tibble(follower_of = unlist(lapply(results, function(x) x$ids)),
+                         user_id = user)
     results <- copy_cursor(df, results)
   }
   results

--- a/R/friends.R
+++ b/R/friends.R
@@ -19,8 +19,8 @@
 #' users <- get_friends("ropensci")
 #' users
 #' }
-#' @return A tibble data frame with two columns, "from_id" for name or ID of target
-#'   user and "to_id" for accounts ID they follow.
+#' @return A tibble data frame with two columns, "friend_of" for name or ID of target
+#'   user and "user_id" for accounts ID they follow.
 #' @export
 #' @references <https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids>
 get_friends <- function(users,
@@ -72,8 +72,8 @@ get_friends_user <- function(user, token, ..., parse = TRUE) {
 
   if (parse) {
     df <- tibble::tibble(
-      from_id = user,
-      to_id = unlist(lapply(results, function(x) x$ids), 
+      friend_of = user,
+      user_id = unlist(lapply(results, function(x) x$ids), 
                      recursive = FALSE, use.names = FALSE)
     )
     results <- copy_cursor(df, results)


### PR DESCRIPTION
Adjust names of columns to ensure consistency and avoid confusion across rtweet tibbles. Key column returned by `get_friends` and `get_followers` is a list of user_ids, for context the linked account should be identified, plus it should be clear the direction of the relationship. 

In order to do this, I have renamed the "from_id" variable as "friend_of" and "follower_of" respectively. The key variable is named "user_id" in both cases. 