### PR TITLE
Geo column of tweets is now a one row data.frame for all tweets

### DIFF
--- a/R/tweet_object.R
+++ b/R/tweet_object.R
@@ -11,7 +11,7 @@ tweet <- function(x) {
                       in_reply_to_user_id = NA_integer_,
                       in_reply_to_user_id_str = NA_character_,
                       in_reply_to_screen_name = NA_character_, 
-                      geo = NA, 
+                      geo = I(list(list())), 
                       coordinates = NA, place = NA, 
                       contributors = NA, is_quote_status = NA, 
                       retweet_count = 0, favorite_count = 0, 
@@ -71,7 +71,10 @@ tweet <- function(x) {
   if (has_name_(x, "scopes")){
     tb$scopes <- split_df(x$scopes)
   }
-  
+  if (has_name_(x, "geo")){
+    tb$geo <- split_df(x$geo)
+  }
+
   if (has_name_(x, "text")) {
     tb$text <- x$text
     tb$display_text_width <- nchar(x$text)

--- a/tests/testthat/_snaps/search_tweets.md
+++ b/tests/testthat/_snaps/search_tweets.md
@@ -10,5 +10,5 @@
     Code
       search_tweets("stats", type = "all")
     Error <rlang_error>
-      `type` must be one of "mixed", "recent", or "popular".
+      `type` must be one of "mixed", "recent", or "popular", not "all".
 

--- a/tests/testthat/test-statuses.R
+++ b/tests/testthat/test-statuses.R
@@ -54,3 +54,10 @@ test_that("Check coordinates on different autoformatting from jsonlite", {
   lu <- lookup_tweets(c("368194158915506176", "1483888984455581705"))
   expect_equal(nrow(lu), 2)
 })
+
+
+test_that("Check that geo works well,  #648", {
+  lu <- lookup_tweets(c("1488182699202383875", "1373362476839022592", "1481348667307180033", 
+    "930475046530936834", "914607458169081858"))
+  expect_true(is.list(lu$geo) && !is.data.frame(lu$geo))
+})


### PR DESCRIPTION
This should close #648. I'm not completely sure why but I think that when rbinding data.frames either the geo column becomes duplicated or it doesn't play nice with the other dimensions. So having a list with 1 row data.frame solves this 