### PR TITLE
Improve auth documentation

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -4,8 +4,15 @@
 #' your personal Twitter account. See [rtweet_app()]/[rtweet_bot] and 
 #' [auth_save()] for other authentication options.
 #' 
+#' It will use the current logged in account on the default browser to detect 
+#' the credentials needed for rtweet and save them as "default".
+#' 
 #' @export
 #' @family authentication
+#' @examples 
+#' \dontrun{
+#' auth_setup_default()
+#' }
 auth_setup_default <- function() {
   auth_save(rtweet_user(), "default")
 }
@@ -55,6 +62,12 @@ auth_setup_default <- function() {
 #' @param bearer_token App bearer token.
 #' @family authentication
 #' @export
+#' @examples 
+#' \dontrun{
+#' rtweet_user()
+#' rtweet_bot()
+#' rtweet_app()
+#' }
 rtweet_user <- function(api_key = NULL, api_secret = NULL) {
   check_installed("httpuv")
   
@@ -143,6 +156,10 @@ print.rtweet_bearer <- function(x, ...) {
 #' @keywords internal
 #' @family authentication
 #' @export
+#' @examples 
+#' \dontrun{
+#' auth_get()
+#' }
 auth_get <- function() {
   if (is.null(.state$auth)) {
     auth_as()
@@ -174,6 +191,8 @@ auth_get <- function() {
 #' 
 #' # later, in a different session...
 #' auth_as("my-app")
+#' # Show all authentications stored
+#' auth_list()
 #' }
 auth_save <- function(auth, name) {
   stopifnot(is_auth(auth), is_string(name))

--- a/R/auth.R
+++ b/R/auth.R
@@ -12,6 +12,8 @@ auth_setup_default <- function() {
 
 #' Authentication options
 #' 
+#' Authenticate methods to use the Twitter API.
+#' 
 #' @description 
 #' There are three ways that you can authenticate with the Twitter API:
 #' 
@@ -43,8 +45,8 @@ auth_setup_default <- function() {
 #' passwords so should generally not be typed into the console (where they
 #' the will be recorded in `.Rhistory`) or recorded in a script (which is
 #' easy to accidentally share). Instead, call these functions without arguments
-#' since the default behaviour is to use [askpass::askpass()] to interactively 
-#' prompt you for the values.
+#' since the default behaviour is to use ask_pass that if possible uses 
+#' [askpass::askpass()] to interactively safely prompt you for the values.
 #' 
 #' @param api_key,api_secret Application API key and secret. These are 
 #'   generally not required for `tweet_user()` since the defaults will use
@@ -156,9 +158,13 @@ auth_get <- function() {
 #' credentials, making it easier to share auth between projects.
 #' Use `auth_list()` to list all saved credentials.
 #' 
+#' The tokens are saved on `tools::R_user_dir("rtweet", "config")`. 
+#' 
 #' @param auth One of [rtweet_app()], [rtweet_bot()], or [rtweet_user()].
-#' @param name Cache name to use.
+#' @param name Name of the file to use.
+#' @return Invisible the path where the authentication is saved.
 #' @family authentication
+#' @seealso [auth_sitrep()] to help finding and managing authentications.
 #' @export
 #' @examples 
 #' \dontrun{
@@ -203,6 +209,7 @@ auth_list <- function() {
 #'   * An auth object created by [rtweet_app()], [rtweet_bot()], or 
 #'     [rtweet_user()].
 #' @return Invisibly returns the previous authentication mechanism.
+#' @seealso [auth_sitrep()] to help finding and managing authentications.
 #' @family authentication
 #' @export
 #' @examples 

--- a/man/auth_as.Rd
+++ b/man/auth_as.Rd
@@ -39,6 +39,8 @@ auth_as("my-saved-app")
 }
 }
 \seealso{
+\code{\link[=auth_sitrep]{auth_sitrep()}} to help finding and managing authentications.
+
 Other authentication: 
 \code{\link{auth_get}()},
 \code{\link{auth_save}()},

--- a/man/auth_get.Rd
+++ b/man/auth_get.Rd
@@ -10,6 +10,11 @@ auth_get()
 If no authentication has been set up for this session, \code{auth_get()} will
 call \code{\link[=auth_as]{auth_as()}} to set it up.
 }
+\examples{
+\dontrun{
+auth_get()
+}
+}
 \seealso{
 Other authentication: 
 \code{\link{auth_as}()},

--- a/man/auth_save.Rd
+++ b/man/auth_save.Rd
@@ -33,6 +33,8 @@ auth_save(auth, "my-app")
 
 # later, in a different session...
 auth_as("my-app")
+# Show all authentications stored
+auth_list()
 }
 }
 \seealso{

--- a/man/auth_save.Rd
+++ b/man/auth_save.Rd
@@ -12,12 +12,18 @@ auth_list()
 \arguments{
 \item{auth}{One of \code{\link[=rtweet_app]{rtweet_app()}}, \code{\link[=rtweet_bot]{rtweet_bot()}}, or \code{\link[=rtweet_user]{rtweet_user()}}.}
 
-\item{name}{Cache name to use.}
+\item{name}{Name of the file to use.}
+}
+\value{
+Invisible the path where the authentication is saved.
 }
 \description{
 Use \code{auth_save()} with \code{\link[=auth_as]{auth_as()}} to avoid repeatedly entering app
 credentials, making it easier to share auth between projects.
 Use \code{auth_list()} to list all saved credentials.
+}
+\details{
+The tokens are saved on \code{tools::R_user_dir("rtweet", "config")}.
 }
 \examples{
 \dontrun{
@@ -30,6 +36,8 @@ auth_as("my-app")
 }
 }
 \seealso{
+\code{\link[=auth_sitrep]{auth_sitrep()}} to help finding and managing authentications.
+
 Other authentication: 
 \code{\link{auth_as}()},
 \code{\link{auth_get}()},

--- a/man/auth_setup_default.Rd
+++ b/man/auth_setup_default.Rd
@@ -11,6 +11,15 @@ You'll need to run this function once per computer so that rtweet can use
 your personal Twitter account. See \code{\link[=rtweet_app]{rtweet_app()}}/\link{rtweet_bot} and
 \code{\link[=auth_save]{auth_save()}} for other authentication options.
 }
+\details{
+It will use the current logged in account on the default browser to detect
+the credentials needed for rtweet and save them as "default".
+}
+\examples{
+\dontrun{
+auth_setup_default()
+}
+}
 \seealso{
 Other authentication: 
 \code{\link{auth_as}()},

--- a/man/rtweet_user.Rd
+++ b/man/rtweet_user.Rd
@@ -62,6 +62,13 @@ since the default behaviour is to use ask_pass that if possible uses
 \code{\link[askpass:askpass]{askpass::askpass()}} to interactively safely prompt you for the values.
 }
 
+\examples{
+\dontrun{
+rtweet_user()
+rtweet_bot()
+rtweet_app()
+}
+}
 \seealso{
 Other authentication: 
 \code{\link{auth_as}()},

--- a/man/rtweet_user.Rd
+++ b/man/rtweet_user.Rd
@@ -50,13 +50,16 @@ no need to because it uses the Twitter app provided by rtweet.
 Use \code{\link[=auth_as]{auth_as()}} to set the default auth mechanism for the current session,
 and \code{\link[=auth_save]{auth_save()}} to save an auth mechanism for use in future sessions.
 }
+\details{
+Authenticate methods to use the Twitter API.
+}
 \section{Security}{
 All of the arguments to these functions are roughly equivalent to
 passwords so should generally not be typed into the console (where they
 the will be recorded in \code{.Rhistory}) or recorded in a script (which is
 easy to accidentally share). Instead, call these functions without arguments
-since the default behaviour is to use \code{\link[askpass:askpass]{askpass::askpass()}} to interactively
-prompt you for the values.
+since the default behaviour is to use ask_pass that if possible uses
+\code{\link[askpass:askpass]{askpass::askpass()}} to interactively safely prompt you for the values.
 }
 
 \seealso{

--- a/vignettes/auth.Rmd
+++ b/vignettes/auth.Rmd
@@ -16,8 +16,8 @@ rtweet's default authentication is shared by all user.
 If it is just for a test, a workshop or a lecture it is fine.
 But if you plan to use it more than a day you will benefit of authenticating yourself.
 
-Using `auth_setup_default()` allows you to act on behalf of your personal Twitter account, as if you were performing actions on twitter.com.
-This mechanism is suited for casual use.
+The **recommended authentication** mechanism is using `auth_setup_default()`.
+It allows you to act on behalf of your personal Twitter account, as if you were performing actions on twitter.com.
 
 If you want to collect a lot of data or implement a bot, you should instead use one of rtweet's two other authentication mechanisms:
 
@@ -26,7 +26,7 @@ If you want to collect a lot of data or implement a bot, you should instead use 
 
 -   **Bot authentication** allows you to create a fully automated Twitter bot that performs actions on its own behalf rather than on behalf of a human.
 
-In either case, you'll need to create your own Twitter app, so we'll start by discussing what an app is and how to create one on the Twitter website.
+In either case, you'll need to create your own Twitter app (yes, it can be confusing), so we'll start by discussing what an app is and how to create one on the Twitter website.
 Next, you'll learn how to use the `rtweet_app()` and `rtweet_bot()` functions to tell rtweet about your app config.
 You'll then learn how to set the default authentication mechanism for the current R session, and how to save it so you can use it in a future session.
 
@@ -39,7 +39,7 @@ library(rtweet)
 You're already familiar with using twitter, either through [the website](https://twitter.com) or an app that you installed on your phone or computer.
 To use twitter from R, you'll need to learn a little more about what's going on behind the scenes.
 The first important concept to grasp is that every request to the Twitter API has to go through an "app".
-Normally, someone else has created the app for you, but now that you're using twitter programmatically, you need to create your own app.
+Normally, someone else has created the app for you, but now that you're using twitter programmatically, you can create your own app.
 (It's still called an app even though you'll be using it through an R package).
 
 To create a Twitter app, you need to first apply for a developer account by following the instructions at <https://developer.twitter.com>.
@@ -51,11 +51,12 @@ You'll only see this once, so make sure to record it in a secure location.
 
 ![](app-info.png){width="548"}
 
-(Don't worry if you forget to save this data: you can always regenerate new values by clicking the "regenerate" button on the "keys and tokens" page.)
+Don't worry if you forget to save this data: you can always regenerate new values by clicking the "regenerate" button on the "keys and tokens" page.
+If you regenerate the previous values will cease to work, so do not use it to get different credentials for an authentication already in use. 
 
 ## Setup
 
-Now that you have an app, you have to tell rtweet about it.
+Now that you have an app registered on twitter.com , you have to tell rtweet about it.
 You'll use either `rtweet_app()` or `rtweet_bot()` depending on whether you want app-style authentication or bot-style authentication as described above.
 
 ### User
@@ -64,13 +65,13 @@ By default `rtweet` uses a common user for all the users.
 Using the default authentication might cause problems while using rtweet. 
 You are sharing the same resource with many people!
 
-If you use rtweet for more than a day or a test it is recommended to set up your own authentication. and you don't want to set up a bot or an app you can use `rtweet_user()`:
+If you use rtweet for more than a day or a learning how to use the package it is recommended to set up your own authentication and you don't want to set up a bot or an app you can use `auth_setup_default()`:
 
-```{r}
-rtweet_user()
+```{r, eval=FALSE}
+auth_setup_default()
 ```
 
-
+It will call `rtweet_user()` to use your current logged account on your default browser as the authentication used by `rtweet` and save it as "default" (See [Saving and loading](Saving-and-loading)).
 
 ### Apps
 
@@ -133,7 +134,10 @@ You can see all the authentication options you have saved with `auth_list()`.
 `auth_list()` reports all the available authentications at the default location (See `auth_save()` details).
 If you use an authentication saved on a different path you can directly use it `auth_as("../authentications/rtweet.rds")`
 
-### on CI
+`auth_setup_default()` saves the authentication as default. 
+So, after your initial setup you can start all your scripts with `auth_as("default")` to load it.
+
+### On continuous integration workflows
 
 On continuous integration you need to provide the keys and tokens as secret variables.
 Otherwise anyone with access to the logs of those checks might use your keys and tokens.
@@ -150,16 +154,12 @@ auth_as(app)
 ```
 
 Don't leave the arguments without values as this won't authenticate.
-Also do not print RTWEET_BEARER or other secrets
-
-```{r}
-token <- rtweet_app()
-search()
-```
+Also do not print RTWEET_BEARER or other secrets.
 
 ## Authentications sitrep
 
 If you want a more complete check up of your authentications you can use `auth_sitrep()`.
+It can help when regenerating credentials and to follow best practices when upgrading rtweet.
 It will return something like these:
 
 
@@ -186,8 +186,7 @@ First looks up old authentications rtweet saved at your home directory (`~`, or 
 Then it reports the authentications found on the new location (rtweet >= 1.0.0).
 For each folder it reports apps and then users and bots authentications.
 It is safe to use in public, as instead of the tokens or keys it reports a letter.
-For users it reports the user_id it reports the id.
+For users authentications it reports the user_id, so that you can check who is that user (`search_users("1051053384")`).
 
-This makes it easier to see if there is a saved authentication with a misleading user_id.
-It also warns you if there is the same key or token for multiple files, as this indicates a misunderstanding.
-You might end up tweeting on your personal account all the recipes a bot should be reporting! 
+This makes it easier to see if there is a saved authentication with a name not matching the user_id.
+It also warns you if there is the same key or token for multiple files, as this indicates a misunderstanding or a duplication of the authentication.

--- a/vignettes/auth.Rmd
+++ b/vignettes/auth.Rmd
@@ -12,8 +12,12 @@ vignette: >
 knitr::opts_chunk$set(echo = TRUE, eval = FALSE, comment = "#>", collapse = TRUE)
 ```
 
-rtweet's default authentication mechanism (`auth_setup_default()`) allows you to act on behalf of your personal Twitter account, as if you were performing actions on twitter.com.
-This mechanism is very simple to set up, but is best suited for casual use.
+rtweet's default authentication is shared by all user.
+If it is just for a test, a workshop or a lecture it is fine.
+But if you plan to use it more than a day you will benefit of authenticating yourself.
+
+Using `auth_setup_default()` allows you to act on behalf of your personal Twitter account, as if you were performing actions on twitter.com.
+This mechanism is suited for casual use.
 
 If you want to collect a lot of data or implement a bot, you should instead use one of rtweet's two other authentication mechanisms:
 
@@ -54,7 +58,21 @@ You'll only see this once, so make sure to record it in a secure location.
 Now that you have an app, you have to tell rtweet about it.
 You'll use either `rtweet_app()` or `rtweet_bot()` depending on whether you want app-style authentication or bot-style authentication as described above.
 
-### rtweet_app()
+### User
+
+By default `rtweet` uses a common user for all the users.
+Using the default authentication might cause problems while using rtweet. 
+You are sharing the same resource with many people!
+
+If you use rtweet for more than a day or a test it is recommended to set up your own authentication. and you don't want to set up a bot or an app you can use `rtweet_user()`:
+
+```{r}
+rtweet_user()
+```
+
+
+
+### Apps
 
 To use app based authentication, run this code:
 
@@ -66,7 +84,7 @@ This will prompt you to enter the bearer token that you recorded earlier.
 
 It's good practice to only provide secrets interactively, because that makes it harder to accidentally share them in either your `.Rhistory` or an `.R` file.
 
-### `rtweet_bot()`
+### Bots
 
 Bot based authentication works similarly:
 
@@ -98,7 +116,7 @@ auth_as(auth)
 ## Saving and loading
 
 `auth_as()` only lasts for a single session; if you close and re-open R, you'll need to repeat the whole process.
-This would be annoying (!) so rtweet also provides a way to save and reload auth across sessions:
+This would be annoying (!) so rtweet also provides a way to save and reload authentications across sessions:
 
 ```{r, eval = FALSE}
 auth_save(auth, "some-name")
@@ -112,3 +130,64 @@ auth_as("some-name")
 ```
 
 You can see all the authentication options you have saved with `auth_list()`.
+`auth_list()` reports all the available authentications at the default location (See `auth_save()` details).
+If you use an authentication saved on a different path you can directly use it `auth_as("../authentications/rtweet.rds")`
+
+### on CI
+
+On continuous integration you need to provide the keys and tokens as secret variables.
+Otherwise anyone with access to the logs of those checks might use your keys and tokens.
+Check your CI documentation about how to do that, but it might be something similar to what [Github does](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+Where secrets are created as environmental variables.
+
+You will need to provide a name of your variable, try to be informative (RTWEET_BEARER, RTWEET_API_KEY, RTWEET_API_SECRET, RTWEET_TOKEN, RTWEET_SECRET).
+
+Usually you later need to load them from the environmental variables and create the token on the CI:
+
+```r
+app <- rtweet_app(bearer_token = Sys.getenv("RTWEET_BEARER"))
+auth_as(app)
+```
+
+Don't leave the arguments without values as this won't authenticate.
+Also do not print RTWEET_BEARER or other secrets
+
+```{r}
+token <- rtweet_app()
+search()
+```
+
+## Authentications sitrep
+
+If you want a more complete check up of your authentications you can use `auth_sitrep()`.
+It will return something like these:
+
+
+```{r, eval = FALSE}
+auth_sitrep()
+## Tokens from rtweet version < 1.0.0 found on /home/user:
+## Empty tokens were found.
+## Choose which is the best path of action for the tokens:
+##                              user_id  key
+## .rtweet_token.rds      My app         <NA>
+## .rtweet_token1.rds My account            A
+## Tokens found on /home/user/.config/R/rtweet:
+##             token
+## my-app2.rds     A
+## Multiple authentications with the same app found!
+## Choose which is the best path of action for the tokens:
+##                       app    user_id key
+## default.rds        rtweet 1051053384   A
+## testing_rtweet.rds rtweet              B
+## All tokens should be moved to/home/user/.config/R/rtweet
+```
+
+First looks up old authentications rtweet saved at your home directory (`~`, or `$HOME`).
+Then it reports the authentications found on the new location (rtweet >= 1.0.0).
+For each folder it reports apps and then users and bots authentications.
+It is safe to use in public, as instead of the tokens or keys it reports a letter.
+For users it reports the user_id it reports the id.
+
+This makes it easier to see if there is a saved authentication with a misleading user_id.
+It also warns you if there is the same key or token for multiple files, as this indicates a misunderstanding.
+You might end up tweeting on your personal account all the recipes a bot should be reporting! 


### PR DESCRIPTION
This should help users of rtweet to manage their authentications.

I increased the documentation of auth_save to indicate where it is saved.
Added some more links to auth_sitrep.
Expanded the vignette to explain how to use tokens on CI and how to read auth_stirep (This might need more feedback)

I strongly suggested to use personal authentication, perhaps too much. But I think this is needed for new users, 
It is based on feedback on #602, and I still want to review the suggestions/material from #624