### PR TITLE
fix message in rtweet_bot authentication

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -115,7 +115,7 @@ rtweet_bot <- function(api_key, api_secret, access_token, access_secret) {
     access_token <- ask_pass("access token")
   }
   if (missing(access_secret)) {
-    access_secret <- ask_pass("access token")
+    access_secret <- ask_pass("access secret")
   }
   
   


### PR DESCRIPTION
Bot authentication is asking for access token twice instead of asking for access token and access secret